### PR TITLE
ci: harden Helm validation tooling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,21 @@ jobs:
 
       - name: Set up Task
         uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task
+          version: 3.49.1
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.1.4
 
       - name: Set up OpenTofu
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
+          # renovate: datasource=github-releases depName=opentofu/opentofu
+          tofu_version: 1.11.6
           tofu_wrapper: false
 
       - name: Set up yq
@@ -38,6 +46,9 @@ jobs:
 
       - name: Set up pluto
         uses: FairwindsOps/pluto/github-action@63548477d6f0c889bde9de2d73e49378e7faeb57 # v5.23.6
+        with:
+          # renovate: datasource=docker depName=us-docker.pkg.dev/fairwinds-ops/oss/pluto
+          IMAGE_TAG: v5.23
 
       - name: Set up kubeconform
         uses: bmuschko/setup-kubeconform@5ccaecbbf012bcb1eeeab66e649db64a477ade8f # v1.0.0

--- a/scripts/validate-kubernetes.sh
+++ b/scripts/validate-kubernetes.sh
@@ -24,6 +24,28 @@ ensure_render_cache_root() {
   [ -n "$render_cache_root" ] || render_cache_root="$(mktemp -d)"
 }
 
+run_helm() {
+  ensure_render_cache_root
+
+  local helm_state_root="${render_cache_root}/helm"
+
+  mkdir -p \
+    "${helm_state_root}/cache/content" \
+    "${helm_state_root}/cache/repository" \
+    "${helm_state_root}/config/registry" \
+    "${helm_state_root}/data"
+
+  env \
+    HELM_CONFIG_HOME="${helm_state_root}/config" \
+    HELM_CACHE_HOME="${helm_state_root}/cache" \
+    HELM_DATA_HOME="${helm_state_root}/data" \
+    HELM_REPOSITORY_CONFIG="${helm_state_root}/config/repositories.yaml" \
+    HELM_REPOSITORY_CACHE="${helm_state_root}/cache/repository" \
+    HELM_REGISTRY_CONFIG="${helm_state_root}/config/registry/config.json" \
+    HELM_CONTENT_CACHE="${helm_state_root}/cache/content" \
+    helm "$@"
+}
+
 yaml_quote() {
   local value="$1"
 
@@ -432,6 +454,7 @@ validate_source() {
 
 render_helm_app() {
   local app="$1"
+  local kubernetes_version="$2"
   local values="${app%app.yaml}values.yaml"
   local repo version name chart chart_name chart_key chart_dir
 
@@ -456,8 +479,8 @@ render_helm_app() {
     repo_name="$(echo "$repo" | md5sum | cut -d" " -f1)"
     repo_ready_file="${render_cache_root}/repos/${repo_name}.ready"
     if [ ! -f "$repo_ready_file" ]; then
-      helm repo add "$repo_name" "$repo" >/dev/null 2>&1 || true
-      helm repo update "$repo_name" >/dev/null 2>&1 || true
+      run_helm repo add "$repo_name" "$repo" >/dev/null 2>&1 || true
+      run_helm repo update "$repo_name" >/dev/null 2>&1 || true
       : >"$repo_ready_file"
     fi
     chart="$repo_name/$name"
@@ -470,12 +493,13 @@ render_helm_app() {
   if [ ! -d "$chart_dir" ]; then
     local pull_dir
     pull_dir="$(mktemp -d "${render_cache_root}/pull.XXXXXX")"
-    helm pull "$chart" --version "$version" --untar --untardir "$pull_dir" >/dev/null 2>&1
+    run_helm pull "$chart" --version "$version" --untar --untardir "$pull_dir" >/dev/null 2>&1
     mv "${pull_dir}/${chart_name}" "$chart_dir"
     rm -rf "$pull_dir"
   fi
 
-  helm template test "$chart_dir" --values "$values" \
+  run_helm template test "$chart_dir" --values "$values" \
+    --kube-version "${kubernetes_version#v}" \
     --api-versions gateway.networking.k8s.io/v1/HTTPRoute
 }
 
@@ -558,7 +582,7 @@ validate_rendered_apps() {
     rendered="${rendered_root}/${relative_path}"
     mkdir -p "$(dirname "$rendered")"
 
-    if ! render_helm_app "$app" >"$rendered"; then
+    if ! render_helm_app "$app" "$kubernetes_version" >"$rendered"; then
       rm -f "$rendered"
       echo "Failed: $(dirname "$app")"
       failed=1

--- a/tests/validate-kubernetes.bats
+++ b/tests/validate-kubernetes.bats
@@ -24,6 +24,15 @@ fi
 '
   write_stub helm '
 printf "helm %s\n" "$*" >> "$STUB_LOG"
+if [[ "${REQUIRE_HELM_STATE_ISOLATION:-}" == "1" ]]; then
+  for var in HELM_CONFIG_HOME HELM_CACHE_HOME HELM_DATA_HOME HELM_REPOSITORY_CONFIG HELM_REPOSITORY_CACHE HELM_REGISTRY_CONFIG HELM_CONTENT_CACHE; do
+    value="${!var:-}"
+    if [[ -z "$value" || "$value" == "${HOME}"* ]]; then
+      echo "unisolated ${var}=${value}" >&2
+      exit 1
+    fi
+  done
+fi
 if [[ "$1" == "pull" ]]; then
   untardir=""
   source=""
@@ -212,6 +221,7 @@ teardown() {
   assert_log_contains 'kubeconform -kubernetes-version 9.9.9'
   assert_log_contains 'pluto detect-files -d '
   assert_log_contains '--target-versions k8s=v9.9.9 -o wide'
+  assert_log_contains '--kube-version 9.9.9'
 }
 
 @test "validate-kubernetes helm-apps renders each app once and reuses the output" {
@@ -357,6 +367,16 @@ EOF
 
 @test "validate-kubernetes helm-apps adds and updates non-OCI Helm repos before rendering" {
   run env REPO_ROOT="${TEST_TMPDIR}" bash scripts/validate-kubernetes.sh helm-apps "${TEST_TMPDIR}/apps/selfhosted/http-demo/app.yaml"
+
+  [ "$status" -eq 0 ]
+  assert_log_contains 'helm repo add abcd1234 https://charts.example.com'
+  assert_log_contains 'helm repo update abcd1234'
+  assert_log_contains 'helm pull abcd1234/demo --version 4.5.6 --untar --untardir'
+  assert_log_contains 'helm template test '
+}
+
+@test "validate-kubernetes helm-apps isolates helm state during rendering" {
+  run env REQUIRE_HELM_STATE_ISOLATION=1 REPO_ROOT="${TEST_TMPDIR}" bash scripts/validate-kubernetes.sh helm-apps "${TEST_TMPDIR}/apps/selfhosted/http-demo/app.yaml"
 
   [ "$status" -eq 0 ]
   assert_log_contains 'helm repo add abcd1234 https://charts.example.com'


### PR DESCRIPTION
## Summary
- pin CI tool versions for Task, Helm, OpenTofu, and Pluto
- render Helm apps with the Tuppr Kubernetes target version
- isolate Helm config/cache/data during rendered validation

## Tests
- task test
- task lint
- helmfile -f bootstrap/helmfile.yaml.gotmpl build