### PR TITLE
fix(gatus): restrict sidecar to HTTPRoute controller

### DIFF
--- a/apps/selfhosted/gatus/values.yaml
+++ b/apps/selfhosted/gatus/values.yaml
@@ -46,7 +46,7 @@ controllers:
           repository: ghcr.io/home-operations/gatus-sidecar
           tag: 0.0.13
         args:
-          - --auto-httproute
+          - --enable-httproute
           - --gateway-name=gateway
           - --output=/config/gatus-sidecar.yaml
         securityContext:


### PR DESCRIPTION
## Summary
- switch gatus-sidecar from `--auto-httproute` to `--enable-httproute`
- keep the sidecar scoped to Gateway API HTTPRoutes, matching the RBAC granted to the Gatus service account

## Why
`--auto-httproute` still lets gatus-sidecar start its default Service, Ingress, and IngressRoute controllers. Those controllers require RBAC that this deployment intentionally does not grant, causing the sidecar to crash-loop before it can generate route checks.

## Validation
- `task fmt`
- `task lint`
- verified in-cluster with a temporary pod using `--enable-httproute`: only the HTTPRoute controller started and it generated the expected route endpoints