### PR TITLE
fix(plex): use identity endpoint for gatus

### DIFF
--- a/apps/media/plex/values.yaml
+++ b/apps/media/plex/values.yaml
@@ -76,6 +76,7 @@ route:
       gethomepage.dev/app: plex
       gatus.home-operations.com/endpoint: |
         group: media
+        url: https://plex.edgard.org/identity
     parentRefs:
       - name: gateway
         namespace: platform-system


### PR DESCRIPTION
## Summary
- point Plex's generated Gatus check at /identity instead of the authenticated root path
- rely on gatus-sidecar's default HTTP 200 condition, matching the existing route annotation pattern

## Verification
- task fmt
- task lint
- reproduced in cluster: https://plex.edgard.org/ returns 401 while https://plex.edgard.org/identity returns 200