### PR TITLE
chore(infra): tune platform controller configs

### DIFF
--- a/apps/kube-system/k8s-gateway/values.yaml
+++ b/apps/kube-system/k8s-gateway/values.yaml
@@ -18,7 +18,6 @@ fallthrough:
 
 # Extra plugins - include health/ready for probes, forward unknowns to Unifi
 extraZonePlugins:
-  - name: log
   - name: errors
   # Health endpoint on :8080 for livenessProbe
   - name: health
@@ -40,6 +39,7 @@ service:
   type: ClusterIP
   port: 53
   clusterIP: 10.96.53.53
+  useTcp: true
 
 # Resources - unlimited per cluster policy
 resources: {}

--- a/apps/kube-system/k8tz/manifests/k8tz-wait-cert-manager.clusterrole.yaml
+++ b/apps/kube-system/k8tz/manifests/k8tz-wait-cert-manager.clusterrole.yaml
@@ -6,20 +6,12 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-weight: "-1"
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,HookFailed,BeforeHookCreation
 rules:
   - apiGroups:
       - apps
     resources:
       - deployments
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
     verbs:
       - get
       - list

--- a/apps/kube-system/k8tz/manifests/k8tz-wait-cert-manager.clusterrolebinding.yaml
+++ b/apps/kube-system/k8tz/manifests/k8tz-wait-cert-manager.clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-weight: "-1"
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,HookFailed,BeforeHookCreation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/apps/kube-system/k8tz/manifests/k8tz-wait-cert-manager.serviceaccount.yaml
+++ b/apps/kube-system/k8tz/manifests/k8tz-wait-cert-manager.serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-weight: "-1"
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,HookFailed,BeforeHookCreation

--- a/apps/kube-system/nfs-provisioner/values.yaml
+++ b/apps/kube-system/nfs-provisioner/values.yaml
@@ -1,5 +1,6 @@
 ---
 controller:
+  enableSnapshotter: false
   resources: {}
 node:
   resources: {}

--- a/apps/platform-system/cert-manager/values.yaml
+++ b/apps/platform-system/cert-manager/values.yaml
@@ -1,7 +1,11 @@
 ---
 strategy:
   type: Recreate
-installCRDs: true
+crds:
+  enabled: true
+  keep: true
+dns01RecursiveNameservers: 1.1.1.1:53,8.8.8.8:53
+dns01RecursiveNameserversOnly: true
 global:
   leaderElection:
     namespace: platform-system

--- a/apps/platform-system/external-dns/values.yaml
+++ b/apps/platform-system/external-dns/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: registry.k8s.io/external-dns/external-dns
   tag: v0.21.0
 triggerLoopOnEvent: true
+interval: 5m
 serviceAccount:
   name: external-dns
 sources:
@@ -22,7 +23,7 @@ provider:
       tag: v0.8.2
     env:
       - name: LOG_LEVEL
-        value: debug
+        value: info
       - name: UNIFI_HOST
         value: https://192.168.1.1
       - name: UNIFI_API_KEY

--- a/apps/platform-system/external-secrets/values.yaml
+++ b/apps/platform-system/external-secrets/values.yaml
@@ -4,6 +4,19 @@ strategy:
 fullnameOverride: external-secrets
 serviceAccount:
   name: external-secrets
+crds:
+  createClusterExternalSecret: false
+  createClusterGenerator: false
+  createClusterPushSecret: false
+  createPushSecret: false
+processClusterExternalSecret: false
+processClusterGenerator: false
+processClusterPushSecret: false
+processPushSecret: false
+processSecretStore: false
+rbac:
+  servicebindings:
+    create: false
 
 livenessProbe:
   enabled: true


### PR DESCRIPTION
## Summary
- enable TCP fallback and reduce normal query logging for k8s-gateway
- migrate cert-manager CRD settings and force DNS01 self-checks through public resolvers
- disable unused NFS snapshotter and unused External Secrets reconcilers
- clean up the k8tz cert-manager wait hook lifecycle and remove unused Job RBAC

## Validation
- task fmt
- task lint
