### PR TITLE
fix(bootstrap): harden bootstrap helper scripts

### DIFF
--- a/scripts/bootstrap-prepare.sh
+++ b/scripts/bootstrap-prepare.sh
@@ -2,10 +2,17 @@
 set -euo pipefail
 
 k8tz_version="${1:?k8tz version is required}"
+warmup_timeout="${BOOTSTRAP_IMAGE_WARMUP_TIMEOUT:-120s}"
 warmup_pod="bootstrap-image-warmup-k8tz-${RANDOM}"
 
-for ns in media platform-system; do
-  kubectl create namespace "${ns}" --dry-run=client -o yaml | kubectl apply -f -
-done
+cleanup_warmup() {
+  kubectl -n kube-system delete pod "${warmup_pod}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
 
-kubectl -n kube-system run -q "${warmup_pod}" --rm --attach --restart=Never --image="quay.io/k8tz/k8tz:${k8tz_version}" -- --help >/dev/null
+trap cleanup_warmup EXIT
+trap 'cleanup_warmup; exit 130' INT
+trap 'cleanup_warmup; exit 143' TERM
+
+kubectl create namespace media --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n kube-system run -q "${warmup_pod}" --restart=Never --image="quay.io/k8tz/k8tz:${k8tz_version}" -- --help >/dev/null
+kubectl -n kube-system wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${warmup_pod}" --timeout="${warmup_timeout}" >/dev/null

--- a/scripts/external-secrets-presync.sh
+++ b/scripts/external-secrets-presync.sh
@@ -10,17 +10,7 @@ wait_medium="${BOOTSTRAP_WAIT_MEDIUM:-120s}"
 
 kubectl wait --for=condition=Established crd/issuers.cert-manager.io crd/certificates.cert-manager.io --timeout="${wait_short}"
 kubectl wait --for=condition=Available deployment/cert-manager-webhook -n platform-system --timeout="${wait_short}"
-cat <<EOF | kubectl apply -f -
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: bitwarden-credentials
-  namespace: platform-system
-type: Opaque
-stringData:
-  token: ${BWS_ACCESS_TOKEN}
-EOF
+kubectl create secret generic bitwarden-credentials --namespace platform-system --from-literal=token="${BWS_ACCESS_TOKEN}" --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -f "${repo_root}/apps/platform-system/external-secrets/manifests/external-secrets-sdk-server-issuer.issuer.yaml"
 kubectl apply -f "${repo_root}/apps/platform-system/external-secrets/manifests/external-secrets-sdk-server-tls.certificate.yaml"
 kubectl wait --for=condition=Ready certificate/external-secrets-sdk-server-tls -n platform-system --timeout="${wait_medium}"


### PR DESCRIPTION
## Summary
- Bound the k8tz bootstrap warmup pod with a configurable wait timeout and cleanup traps.
- Narrowed bootstrap namespace pre-creation to `media`, leaving Helmfile to create Helm release namespaces.
- Replaced raw Bitwarden Secret YAML interpolation with `kubectl create secret generic` piped to apply.

## Validation
- `shellcheck --severity=warning scripts/*.sh`
- `helmfile -f bootstrap/helmfile.yaml.gotmpl show-dag`
- `task lint`