### PR TITLE
fix(renovate): constrain CI tool extraction

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -64,9 +64,10 @@
       description: "CI tool versions in GitHub Actions workflow",
       managerFilePatterns: ["/^\\.github\\/workflows\\/ci\\.ya?ml$/"],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)[\\s\\S]*?version:\\s*[\"']?(?<currentValue>v[0-9.]+)[\"']?",
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)[\\s\\S]*?kubeconform-version:\\s*[\"']?(?<currentValue>[0-9.]+)[\"']?",
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)[\\s\\S]*?version:\\s*[\"']?(?<currentValue>[0-9.]+)[\"']?",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*version:\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*tofu_version:\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*IMAGE_TAG:\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*kubeconform-version:\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?",
       ],
     },
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,7 +37,7 @@ tasks:
       - shellcheck --severity=warning scripts/*.sh
       - yamllint -c .yamllint .
       - '"{{.TASKFILE_DIR}}/scripts/validate-kubernetes.sh"'
-      - tf_data_dir=$(mktemp -d) && trap 'rm -rf "$tf_data_dir"' EXIT && cd terraform && TF_DATA_DIR="$tf_data_dir" tofu init -backend=false >/dev/null 2>&1 && TF_DATA_DIR="$tf_data_dir" tofu validate
+      - tf_data_dir=$(mktemp -d) && trap 'rm -rf "$tf_data_dir"' EXIT && cd terraform && TF_DATA_DIR="$tf_data_dir" tofu init -upgrade -backend=false >/dev/null 2>&1 && TF_DATA_DIR="$tf_data_dir" tofu validate
 
   precommit:
     desc: Format code and run the offline validation checks


### PR DESCRIPTION
## Summary
- constrain CI Renovate regexes so tool hints only capture the immediately following workflow input
- initialize OpenTofu lint with provider upgrade because this repo ignores provider lock files

## Verification
- task fmt
- npx --yes --package renovate@43.150.0 renovate-config-validator .renovaterc.json5
- shellcheck --severity=warning scripts/*.sh
- task lint