### PR TITLE
fix(bambuddy): provide writable log directory

### DIFF
--- a/apps/selfhosted/bambuddy/values.yaml
+++ b/apps/selfhosted/bambuddy/values.yaml
@@ -72,6 +72,10 @@ route:
             port: 8000
 
 persistence:
+  logs:
+    type: emptyDir
+    globalMounts:
+      - path: /app/logs
   data:
     type: persistentVolumeClaim
     accessMode: ReadWriteOnce


### PR DESCRIPTION
## Summary
- mount /app/logs as an emptyDir for Bambuddy
- keep the non-root security context unchanged

## Verification
- rendered app-template for Bambuddy and confirmed /app/logs is mounted
- task fmt
- task lint