### PR TITLE
Fix named Argo app refresh task

### DIFF
--- a/scripts/argocd-app-sync.sh
+++ b/scripts/argocd-app-sync.sh
@@ -4,9 +4,15 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 APP="${APP:-}"
-FILTER=""
 
-[[ -n "$APP" ]] && FILTER="-l app=$APP"
+patch_app() {
+  kubectl -n argocd patch "$1" --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
+}
 
-kubectl -n argocd get applications $FILTER -o name | \
-  xargs -r -n1 kubectl -n argocd patch --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' || true
+if [ -n "$APP" ]; then
+  patch_app "application/${APP}"
+else
+  while IFS= read -r app; do
+    patch_app "$app"
+  done < <(kubectl -n argocd get applications -o name)
+fi

--- a/scripts/test-argocd-app-sync.sh
+++ b/scripts/test-argocd-app-sync.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "${tmp_dir}/bin"
+
+cat >"${tmp_dir}/bin/kubectl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'kubectl' >>"${COMMAND_LOG:?}"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >>"$COMMAND_LOG"
+done
+printf '\n' >>"$COMMAND_LOG"
+
+if [ "$*" = "-n argocd get applications -o name" ]; then
+  printf '%s\n' application/homeassistant application/tuppr
+fi
+SH
+
+chmod +x "${tmp_dir}/bin/kubectl"
+
+export PATH="${tmp_dir}/bin:${PATH}"
+export COMMAND_LOG="${tmp_dir}/commands.log"
+
+APP=tuppr "${repo_root}/scripts/argocd-app-sync.sh"
+grep -F $'kubectl\t-n\targocd\tpatch\tapplication/tuppr\t--type\tmerge\t-p\t{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' "$COMMAND_LOG" >/dev/null
+
+: >"$COMMAND_LOG"
+"${repo_root}/scripts/argocd-app-sync.sh"
+grep -F $'kubectl\t-n\targocd\tget\tapplications\t-o\tname' "$COMMAND_LOG" >/dev/null
+grep -F $'kubectl\t-n\targocd\tpatch\tapplication/homeassistant\t--type\tmerge\t-p\t{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' "$COMMAND_LOG" >/dev/null
+grep -F $'kubectl\t-n\targocd\tpatch\tapplication/tuppr\t--type\tmerge\t-p\t{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' "$COMMAND_LOG" >/dev/null


### PR DESCRIPTION
## Summary
- make task argo:sync app=<name> patch the Application by name
- preserve the all-app refresh behavior
- add shell tests for named and all-app refresh paths

## Verification
- scripts/test-argocd-app-sync.sh
- task fmt
- task lint