### PR TITLE
fix(homebridge): mount generated configmap

### DIFF
--- a/apps/home-automation/homebridge/values.yaml
+++ b/apps/home-automation/homebridge/values.yaml
@@ -118,7 +118,7 @@ persistence:
       - path: /homebridge
   config:
     type: configMap
-    name: homebridge-config
+    name: homebridge
     globalMounts:
       - path: /config/config.json
         subPath: config.json


### PR DESCRIPTION
## Summary
- mount the generated Homebridge ConfigMap name in the pod volume
- unblocks the Homebridge init container, which is currently waiting on missing configmap/homebridge-config

## Validation
- task fmt
- task lint