### PR TITLE
fix(homebridge): pin keylights bonjour dependency

### DIFF
--- a/apps/home-automation/homebridge/values.yaml
+++ b/apps/home-automation/homebridge/values.yaml
@@ -41,7 +41,7 @@ controllers:
             if [ ! -f /homebridge/config.json ]; then
               cp /config/config.json /homebridge/config.json
             fi
-            npm install --prefix /homebridge homebridge-keylights@1.3.3 --omit=dev --no-fund --no-audit
+            npm install --prefix /homebridge homebridge-keylights@1.3.3 bonjour-service@1.3.0 --omit=dev --no-fund --no-audit
         securityContext:
           privileged: true
     containers:


### PR DESCRIPTION
## Summary
- pin bonjour-service to 1.3.0 alongside homebridge-keylights
- avoids the current 1.4.0 resolution that breaks the plugin's Bonjour import at runtime

## Validation
- task fmt
- task lint
- verified bonjour-service@1.3.0 exports Bonjour with a local npm install