### PR TITLE
fix(homebridge): use static Elgato HTTP lights

### DIFF
--- a/apps/home-automation/homebridge/values.yaml
+++ b/apps/home-automation/homebridge/values.yaml
@@ -38,10 +38,9 @@ controllers:
           - |
             set -eu
             mkdir -p /homebridge
-            if [ ! -f /homebridge/config.json ]; then
-              cp /config/config.json /homebridge/config.json
-            fi
-            npm install --prefix /homebridge homebridge-keylights@1.3.3 bonjour-service@1.3.0 --omit=dev --no-fund --no-audit
+            cp /config/config.json /homebridge/config.json
+            npm uninstall --prefix /homebridge homebridge-keylights bonjour-service --no-fund --no-audit || true
+            npm install --prefix /homebridge homebridge-http-lightbulb@1.2.4 --omit=dev --no-fund --no-audit
         securityContext:
           privileged: true
     containers:
@@ -135,16 +134,113 @@ configMaps:
             "port": 51826,
             "pin": "518-62-349"
           },
-          "accessories": [],
+          "accessories": [
+            {
+              "accessory": "HTTP-LIGHTBULB",
+              "name": "Office Key Light Left",
+              "debug": false,
+              "onUrl": {
+                "url": "http://192.168.1.40:9123/elgato/lights",
+                "method": "PUT",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": "{\"numberOfLights\":1,\"lights\":[{\"on\":1}]}"
+              },
+              "offUrl": {
+                "url": "http://192.168.1.40:9123/elgato/lights",
+                "method": "PUT",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": "{\"numberOfLights\":1,\"lights\":[{\"on\":0}]}"
+              },
+              "statusUrl": "http://192.168.1.40:9123/elgato/lights",
+              "statusPattern": "\"on\":1",
+              "brightness": {
+                "statusUrl": "http://192.168.1.40:9123/elgato/lights",
+                "statusPattern": "\"brightness\":(\\d*)",
+                "setUrl": {
+                  "url": "http://192.168.1.40:9123/elgato/lights",
+                  "method": "PUT",
+                  "headers": {
+                    "Content-Type": "application/json"
+                  },
+                  "body": "{\"numberOfLights\":1,\"lights\":[{\"brightness\":%s}]}"
+                }
+              },
+              "colorTemperature": {
+                "statusUrl": "http://192.168.1.40:9123/elgato/lights",
+                "statusPattern": "\"temperature\":(\\d*)",
+                "unit": "mired",
+                "minValue": 143,
+                "maxValue": 344,
+                "setUrl": {
+                  "url": "http://192.168.1.40:9123/elgato/lights",
+                  "method": "PUT",
+                  "headers": {
+                    "Content-Type": "application/json"
+                  },
+                  "body": "{\"numberOfLights\":1,\"lights\":[{\"temperature\":%s}]}"
+                }
+              }
+            },
+            {
+              "accessory": "HTTP-LIGHTBULB",
+              "name": "Office Key Light Right",
+              "debug": false,
+              "onUrl": {
+                "url": "http://192.168.1.94:9123/elgato/lights",
+                "method": "PUT",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": "{\"numberOfLights\":1,\"lights\":[{\"on\":1}]}"
+              },
+              "offUrl": {
+                "url": "http://192.168.1.94:9123/elgato/lights",
+                "method": "PUT",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": "{\"numberOfLights\":1,\"lights\":[{\"on\":0}]}"
+              },
+              "statusUrl": "http://192.168.1.94:9123/elgato/lights",
+              "statusPattern": "\"on\":1",
+              "brightness": {
+                "statusUrl": "http://192.168.1.94:9123/elgato/lights",
+                "statusPattern": "\"brightness\":(\\d*)",
+                "setUrl": {
+                  "url": "http://192.168.1.94:9123/elgato/lights",
+                  "method": "PUT",
+                  "headers": {
+                    "Content-Type": "application/json"
+                  },
+                  "body": "{\"numberOfLights\":1,\"lights\":[{\"brightness\":%s}]}"
+                }
+              },
+              "colorTemperature": {
+                "statusUrl": "http://192.168.1.94:9123/elgato/lights",
+                "statusPattern": "\"temperature\":(\\d*)",
+                "unit": "mired",
+                "minValue": 143,
+                "maxValue": 344,
+                "setUrl": {
+                  "url": "http://192.168.1.94:9123/elgato/lights",
+                  "method": "PUT",
+                  "headers": {
+                    "Content-Type": "application/json"
+                  },
+                  "body": "{\"numberOfLights\":1,\"lights\":[{\"temperature\":%s}]}"
+                }
+              }
+            }
+          ],
           "platforms": [
             {
-              "name": "Elgato Key Lights",
-              "pollingRate": 1000,
-              "powerOnBehavior": 1,
-              "powerOnBrightness": 20,
-              "powerOnTemperature": 4695,
-              "useIP": true,
-              "platform": "ElgatoKeyLights"
+              "name": "Config",
+              "port": 8581,
+              "platform": "config"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- replace Bonjour-based homebridge-keylights with homebridge-http-lightbulb
- configure static PUT/body controls for Office Key Light Left and Right
- overwrite the persisted Homebridge config from GitOps on init so config changes apply to the PVC
- uninstall the previous keylights/bonjour packages during init for a clean runtime

## Validation
- embedded Homebridge config parses with jq
- task fmt
- task lint
- in-cluster check showed Homebridge healthy but Bonjour discovery returned no _elg._tcp services