### PR TITLE
fix(homebridge): provide writable localtime

### DIFF
--- a/apps/home-automation/homebridge/values.yaml
+++ b/apps/home-automation/homebridge/values.yaml
@@ -38,6 +38,7 @@ controllers:
           - |
             set -eu
             mkdir -p /homebridge
+            cp /usr/share/zoneinfo/Europe/Warsaw /localtime/localtime
             cp /config/config.json /homebridge/config.json
             rm -f /homebridge/accessories/cachedAccessories
             npm uninstall --prefix /homebridge homebridge-keylights bonjour-service --no-fund --no-audit || true
@@ -123,6 +124,15 @@ persistence:
       - path: /config/config.json
         subPath: config.json
         readOnly: true
+  localtime:
+    type: emptyDir
+    advancedMounts:
+      main:
+        init-config:
+          - path: /localtime
+        app:
+          - path: /etc/localtime
+            subPath: localtime
 
 configMaps:
   homebridge-config:


### PR DESCRIPTION
## Summary
- seed the Europe/Warsaw zoneinfo file into an emptyDir during init
- mount that file at /etc/localtime for the Homebridge app container
- keeps TZ=Europe/Warsaw while avoiding the image's read-only /etc/localtime startup warning

## Validation
- rendered app-template deployment includes localtime mounts for init-config and app
- embedded Homebridge config parses with jq
- task fmt
- task lint