### PR TITLE
fix(homebridge): disable k8tz injection

### DIFF
--- a/apps/home-automation/homebridge/values.yaml
+++ b/apps/home-automation/homebridge/values.yaml
@@ -16,6 +16,7 @@ controllers:
       reloader.stakater.com/auto: "true"
     pod:
       annotations:
+        k8tz.io/inject: "false"
         k8s.v1.cni.cncf.io/networks: |-
           [
             {


### PR DESCRIPTION
## Summary
- opt Homebridge out of k8tz mutation with k8tz.io/inject=false
- prevents k8tz from overriding the writable /etc/localtime mount with a read-only injected mount

## Validation
- rendered app-template pod annotation includes k8tz.io/inject=false
- embedded Homebridge config parses with jq
- task fmt
- task lint