### PR TITLE
fix(homebridge): remove redundant localtime mount

### DIFF
--- a/apps/home-automation/homebridge/values.yaml
+++ b/apps/home-automation/homebridge/values.yaml
@@ -39,7 +39,6 @@ controllers:
           - |
             set -eu
             mkdir -p /homebridge
-            cp /usr/share/zoneinfo/Europe/Warsaw /localtime/localtime
             cp /config/config.json /homebridge/config.json
             rm -f /homebridge/accessories/cachedAccessories
             npm uninstall --prefix /homebridge homebridge-keylights bonjour-service --no-fund --no-audit || true
@@ -125,15 +124,6 @@ persistence:
       - path: /config/config.json
         subPath: config.json
         readOnly: true
-  localtime:
-    type: emptyDir
-    advancedMounts:
-      main:
-        init-config:
-          - path: /localtime
-        app:
-          - path: /etc/localtime
-            subPath: localtime
 
 configMaps:
   homebridge-config:


### PR DESCRIPTION
## Summary
- remove the localtime emptyDir and init copy added in #220
- keep the k8tz opt-out from #221, which is the actual fix for the Homebridge timezone warning

## Validation
- rendered app-template deployment has no localtime volume and keeps k8tz.io/inject=false
- embedded Homebridge config parses with jq
- task fmt
- task lint
- test pod with k8tz.io/inject=false and TZ=Europe/Warsaw started without the /etc/localtime warning