### PR TITLE
fix(ansible): resolve tofu binary path for plans

### DIFF
--- a/ansible/roles/tofu/defaults/main.yml
+++ b/ansible/roles/tofu/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-tofu_binary_path: tofu
+tofu_binary_path: "{{ lookup('env', 'TOFU_BINARY_PATH') | default(lookup('ansible.builtin.pipe', 'command -v tofu'), true) }}"
 tofu_project_path: "{{ lookup('env', 'TERRAFORM_DIR') | default(repo_root + '/terraform', true) }}"
 tofu_aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
 tofu_aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"

--- a/ansible/tests/native-conventions.yml
+++ b/ansible/tests/native-conventions.yml
@@ -165,9 +165,26 @@
         src: "{{ conventions_repo_root }}/ansible/roles/tofu/defaults/main.yml"
       register: conventions_tofu_defaults
 
+    - name: Load tofu role defaults
+      ansible.builtin.include_vars:
+        file: "{{ conventions_repo_root }}/ansible/roles/tofu/defaults/main.yml"
+        name: conventions_tofu_defaults_vars
+
     - name: Assert tofu clean preserves wildcard cleanup
       ansible.builtin.assert:
         that:
           - "'tofu_clean_file_patterns' in (conventions_tofu_defaults.content | b64decode)"
           - "'*.tfplan' in (conventions_tofu_defaults.content | b64decode)"
           - "'terraform.tfstate*' in (conventions_tofu_defaults.content | b64decode)"
+
+    - name: Check tofu binary path
+      ansible.builtin.stat:
+        path: "{{ conventions_tofu_defaults_vars.tofu_binary_path }}"
+      register: conventions_tofu_binary
+
+    - name: Assert tofu binary path resolves for Terraform module
+      ansible.builtin.assert:
+        that:
+          - conventions_tofu_defaults_vars.tofu_binary_path is match('^/')
+          - conventions_tofu_binary.stat.exists
+          - conventions_tofu_binary.stat.executable


### PR DESCRIPTION
## Summary
- Resolve `tofu_binary_path` to an absolute executable path for `community.general.terraform`.
- Keep `TOFU_BINARY_PATH` as an override for non-standard OpenTofu installs.
- Add a native convention check that the Terraform module binary path is absolute and executable.

## Validation
- `direnv exec . task tf:plan`
- `direnv exec . task lint`
