### PR TITLE
Harden Ansible-native Talos and platform flows

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -195,7 +195,7 @@ tasks:
         - TALOS_NODE
         - K8S_VERSION
     cmds:
-      - '"{{.ANSIBLE_PLAYBOOK}}" ansible/playbooks/talos-upgrade-k8s.yml -e "k8s_version={{.K8S_VERSION}}"'
+      - '"{{.ANSIBLE_PLAYBOOK}}" ansible/playbooks/talos-upgrade-k8s.yml'
 
   # Platform and Argo operations
   platform:create:

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -8,3 +8,4 @@ kube_context: "{{ lookup('env', 'KUBE_CONTEXT') | default('admin@' + talos_clust
 talos_cluster_name: "{{ lookup('env', 'TALOS_CLUSTER_NAME') | default('homelab', true) }}"
 talos_install_disk: "{{ lookup('env', 'TALOS_INSTALL_DISK') }}"
 talos_node: "{{ lookup('env', 'TALOS_NODE') }}"
+k8s_version: "{{ lookup('env', 'K8S_VERSION') }}"

--- a/ansible/roles/platform/tasks/destroy.yml
+++ b/ansible/roles/platform/tasks/destroy.yml
@@ -6,7 +6,6 @@
     state: absent
     src: "{{ repo_root }}/{{ platform_argocd_root_application_manifest }}"
     wait: true
-  failed_when: false
 
 - name: Remove bootstrap Helm releases
   kubernetes.core.helm:

--- a/ansible/roles/platform/tasks/wait_condition.yml
+++ b/ansible/roles/platform/tasks/wait_condition.yml
@@ -7,14 +7,10 @@
     kind: "{{ platform_wait_kind }}"
     name: "{{ platform_wait_name }}"
     namespace: "{{ platform_wait_namespace if platform_wait_namespace | default('') | length > 0 else omit }}"
+    wait: true
+    wait_condition:
+      type: "{{ platform_wait_condition_type }}"
+      status: "{{ platform_wait_condition_status | default('True') }}"
+    wait_sleep: "{{ platform_wait_delay | default(platform_wait_default_delay) }}"
+    wait_timeout: "{{ (platform_wait_retries | default(platform_wait_default_retries) | int) * (platform_wait_delay | default(platform_wait_default_delay) | int) }}"
   register: platform_wait_result
-  until:
-    - platform_wait_result.resources | length > 0
-    - >-
-      platform_wait_result.resources[0].status.conditions | default([])
-      | selectattr('type', 'equalto', platform_wait_condition_type)
-      | selectattr('status', 'equalto', platform_wait_condition_status | default('True'))
-      | list
-      | length > 0
-  retries: "{{ platform_wait_retries | default(platform_wait_default_retries) }}"
-  delay: "{{ platform_wait_delay | default(platform_wait_default_delay) }}"

--- a/ansible/roles/talos/tasks/apply.yml
+++ b/ansible/roles/talos/tasks/apply.yml
@@ -6,6 +6,7 @@
     fail_msg: TALOS_NODE is required.
 
 - name: Configure Talos endpoint
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl
@@ -15,6 +16,7 @@
   changed_when: false
 
 - name: Check whether Talos API already trusts local config
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl
@@ -27,6 +29,7 @@
   changed_when: false
 
 - name: Apply Talos control plane config
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv: >-
       {{

--- a/ansible/roles/talos/tasks/bootstrap.yml
+++ b/ansible/roles/talos/tasks/bootstrap.yml
@@ -7,6 +7,7 @@
     fail_msg: TALOS_NODE and TALOS_CLUSTER_NAME are required.
 
 - name: Wait for Talos API
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl
@@ -20,6 +21,7 @@
   changed_when: false
 
 - name: Bootstrap Talos control plane
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl
@@ -27,10 +29,13 @@
       - --nodes
       - "{{ talos_node }}"
   register: talos_bootstrap_result
-  failed_when: false
+  failed_when:
+    - talos_bootstrap_result.rc != 0
+    - "'already bootstrapped' not in ((talos_bootstrap_result.stdout | default('') + talos_bootstrap_result.stderr | default('')) | lower)"
   changed_when: talos_bootstrap_result.rc == 0
 
 - name: Wait for Talos health
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl
@@ -42,6 +47,7 @@
   changed_when: false
 
 - name: Fetch kubeconfig
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl

--- a/ansible/roles/talos/tasks/generate.yml
+++ b/ansible/roles/talos/tasks/generate.yml
@@ -7,15 +7,16 @@
       - talos_install_disk | length > 0
     fail_msg: TALOS_NODE, TALOS_CLUSTER_NAME, and TALOS_INSTALL_DISK are required.
 
-- name: Create temporary Talos output directory
-  ansible.builtin.tempfile:
-    state: directory
-    suffix: talos
-  register: talos_generate_output
-
 - name: Generate Talos config from vaulted secrets
+  when: not ansible_check_mode
   no_log: true
   block:
+    - name: Create temporary Talos output directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: talos
+      register: talos_generate_output
+
     - name: Create temporary Talos secrets file
       ansible.builtin.tempfile:
         state: file
@@ -46,6 +47,26 @@
           - "{{ talos_generate_output.path }}"
           - --force
       changed_when: true
+
+    - name: Ensure local Talos config directory exists
+      ansible.builtin.file:
+        path: "{{ talos_config_dir }}"
+        state: directory
+        mode: "0700"
+
+    - name: Install generated talosconfig
+      ansible.builtin.copy:
+        src: "{{ talos_generate_output.path }}/talosconfig"
+        dest: "{{ talos_config_path }}"
+        mode: "0600"
+        remote_src: true
+
+    - name: Install generated control plane config
+      ansible.builtin.copy:
+        src: "{{ talos_generate_output.path }}/controlplane.yaml"
+        dest: "{{ talos_controlplane_config_path }}"
+        mode: "0600"
+        remote_src: true
   always:
     - name: Remove temporary Talos secrets file
       ansible.builtin.file:
@@ -53,27 +74,8 @@
         state: absent
       when: talos_generate_secrets_temp is defined
 
-- name: Ensure local Talos config directory exists
-  ansible.builtin.file:
-    path: "{{ talos_config_dir }}"
-    state: directory
-    mode: "0700"
-
-- name: Install generated talosconfig
-  ansible.builtin.copy:
-    src: "{{ talos_generate_output.path }}/talosconfig"
-    dest: "{{ talos_config_path }}"
-    mode: "0600"
-    remote_src: true
-
-- name: Install generated control plane config
-  ansible.builtin.copy:
-    src: "{{ talos_generate_output.path }}/controlplane.yaml"
-    dest: "{{ talos_controlplane_config_path }}"
-    mode: "0600"
-    remote_src: true
-
-- name: Remove temporary Talos output directory
-  ansible.builtin.file:
-    path: "{{ talos_generate_output.path }}"
-    state: absent
+    - name: Remove temporary Talos output directory
+      ansible.builtin.file:
+        path: "{{ talos_generate_output.path | default('') }}"
+        state: absent
+      when: talos_generate_output is defined

--- a/ansible/roles/talos/tasks/reset.yml
+++ b/ansible/roles/talos/tasks/reset.yml
@@ -6,6 +6,7 @@
     fail_msg: TALOS_NODE is required.
 
 - name: Reset Talos node
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl

--- a/ansible/roles/talos/tasks/upgrade.yml
+++ b/ansible/roles/talos/tasks/upgrade.yml
@@ -21,13 +21,17 @@
       - --wait
 
 - name: Upgrade Talos node
-  when: not (talos_upgrade_test_mode | default(false))
+  when:
+    - not (talos_upgrade_test_mode | default(false))
+    - not ansible_check_mode
   ansible.builtin.command:
     argv: "{{ talos_upgrade_command }}"
   changed_when: true
 
 - name: Read Kubernetes nodes
-  when: not (talos_upgrade_test_mode | default(false))
+  when:
+    - not (talos_upgrade_test_mode | default(false))
+    - not ansible_check_mode
   kubernetes.core.k8s_info:
     kubeconfig: "{{ kubeconfig_path }}"
     context: "{{ kube_context }}"
@@ -41,6 +45,7 @@
   loop: "{{ talos_upgrade_nodes.resources }}"
   when: >-
     not (talos_upgrade_test_mode | default(false))
+    and not ansible_check_mode
     and (
       item.metadata.name == talos_node
       or (
@@ -55,6 +60,7 @@
 - name: Uncordon upgraded Kubernetes node
   when:
     - not (talos_upgrade_test_mode | default(false))
+    - not ansible_check_mode
     - talos_upgrade_kubernetes_node is defined
   kubernetes.core.k8s:
     kubeconfig: "{{ kubeconfig_path }}"
@@ -69,7 +75,9 @@
         unschedulable: false
 
 - name: Read Talos server version
-  when: not (talos_upgrade_test_mode | default(false))
+  when:
+    - not (talos_upgrade_test_mode | default(false))
+    - not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl
@@ -80,7 +88,9 @@
   changed_when: false
 
 - name: Assert Talos server version
-  when: not (talos_upgrade_test_mode | default(false))
+  when:
+    - not (talos_upgrade_test_mode | default(false))
+    - not ansible_check_mode
   ansible.builtin.assert:
     that:
       - talos_upgrade.installer.version in talos_upgrade_version.stdout

--- a/ansible/roles/talos/tasks/upgrade_k8s.yml
+++ b/ansible/roles/talos/tasks/upgrade_k8s.yml
@@ -8,6 +8,7 @@
     fail_msg: TALOS_NODE and k8s_version are required.
 
 - name: Upgrade Kubernetes control plane
+  when: not ansible_check_mode
   ansible.builtin.command:
     argv:
       - talosctl

--- a/ansible/tests/native-conventions.yml
+++ b/ansible/tests/native-conventions.yml
@@ -83,6 +83,7 @@
           - "'.VENV_DIR}}/bin/ansible-playbook' in (conventions_taskfile.content | b64decode)"
           - "'.ansible/collections' in (conventions_taskfile.content | b64decode)"
           - "'task deps' in (conventions_taskfile.content | b64decode)"
+          - '''-e "k8s_version='' not in (conventions_taskfile.content | b64decode)'
         fail_msg: "Taskfile compatibility wrappers do not meet strict Ansible gate expectations."
 
     - name: Read inventory group vars
@@ -95,6 +96,8 @@
         that:
           - "'ansible_python_interpreter' in (conventions_inventory_vars.content | b64decode)"
           - "'.venv/bin/python' in (conventions_inventory_vars.content | b64decode)"
+          - "'k8s_version' in (conventions_inventory_vars.content | b64decode)"
+          - "'K8S_VERSION' in (conventions_inventory_vars.content | b64decode)"
 
     - name: Find Ansible task files
       ansible.builtin.find:
@@ -159,6 +162,63 @@
         that:
           - "'always:' in (conventions_k8tz_warmup.content | b64decode)"
           - "'Remove k8tz warmup pod' in (conventions_k8tz_warmup.content | b64decode)"
+
+    - name: Read Talos generate tasks
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/ansible/roles/talos/tasks/generate.yml"
+      register: conventions_talos_generate
+
+    - name: Assert Talos generate cleans all temporary files in always
+      ansible.builtin.assert:
+        that:
+          - "'always:' in (conventions_talos_generate.content | b64decode)"
+          - "'    - name: Remove temporary Talos secrets file' in (conventions_talos_generate.content | b64decode)"
+          - "'    - name: Remove temporary Talos output directory' in (conventions_talos_generate.content | b64decode)"
+
+    - name: Read platform wait condition tasks
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/ansible/roles/platform/tasks/wait_condition.yml"
+      register: conventions_platform_wait_condition
+
+    - name: Assert platform waits use Kubernetes module-native waiting
+      ansible.builtin.assert:
+        that:
+          - "'wait: true' in (conventions_platform_wait_condition.content | b64decode)"
+          - "'wait_condition:' in (conventions_platform_wait_condition.content | b64decode)"
+          - "'wait_sleep:' in (conventions_platform_wait_condition.content | b64decode)"
+          - "'wait_timeout:' in (conventions_platform_wait_condition.content | b64decode)"
+          - "'until:' not in (conventions_platform_wait_condition.content | b64decode)"
+
+    - name: Read platform destroy tasks
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/ansible/roles/platform/tasks/destroy.yml"
+      register: conventions_platform_destroy
+
+    - name: Assert platform destroy does not hide root application deletion failures
+      ansible.builtin.assert:
+        that:
+          - "'failed_when: false' not in (conventions_platform_destroy.content | b64decode)"
+
+    - name: Read Talos command task files
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/{{ item }}"
+      loop:
+        - ansible/roles/talos/tasks/apply.yml
+        - ansible/roles/talos/tasks/bootstrap.yml
+        - ansible/roles/talos/tasks/generate.yml
+        - ansible/roles/talos/tasks/reset.yml
+        - ansible/roles/talos/tasks/upgrade.yml
+        - ansible/roles/talos/tasks/upgrade_k8s.yml
+      register: conventions_talos_command_task_files
+
+    - name: Assert Talos side-effecting tasks support check mode
+      ansible.builtin.assert:
+        that:
+          - "'ansible_check_mode' in (item.content | b64decode)"
+        fail_msg: "Talos side-effecting task file lacks check-mode guards: {{ item.item }}"
+      loop: "{{ conventions_talos_command_task_files.results }}"
+      loop_control:
+        label: "{{ item.item }}"
 
     - name: Read tofu role defaults
       ansible.builtin.slurp:


### PR DESCRIPTION
## Summary
- Move `K8S_VERSION` into Ansible inventory and remove the `talos:upgrade-k8s` extra-vars override
- Replace the custom Kubernetes wait loop with module-native waiting and stop hiding Argo CD destroy failures
- Tighten Talos command handling with check-mode guards and safer temp-file cleanup
- Expand the Ansible convention test coverage for the updated behaviors

## Testing
- `ansible/tests/native-conventions.yml` passes with the new contract checks
- `task fmt` passed
- `task lint` passed