### PR TITLE
Use official OCI chart sources

### DIFF
--- a/apps/kube-system/k8s-gateway/app.yaml
+++ b/apps/kube-system/k8s-gateway/app.yaml
@@ -1,7 +1,7 @@
 ---
 chart:
-  repo: https://k8s-gateway.github.io/k8s_gateway/
-  name: k8s-gateway
+  repo: oci://ghcr.io/k8s-gateway/charts/k8s-gateway
+  path: "."
   version: 3.7.1
 sync:
   wave: "-4"

--- a/apps/platform-system/cert-manager/app.yaml
+++ b/apps/platform-system/cert-manager/app.yaml
@@ -1,7 +1,7 @@
 ---
 chart:
-  repo: https://charts.jetstack.io
-  name: cert-manager
+  repo: oci://quay.io/jetstack/charts/cert-manager
+  path: "."
   version: v1.20.2
 sync:
   wave: "-4"


### PR DESCRIPTION
## Summary
- migrate cert-manager to the official Jetstack OCI chart registry
- migrate k8s-gateway to the official maintained fork's OCI chart registry
- leave external-dns and csi-driver-nfs on HTTP sources because they still lack official OCI chart publishing

## Verification
- helm show chart oci://quay.io/jetstack/charts/cert-manager --version v1.20.2
- helm show chart oci://ghcr.io/k8s-gateway/charts/k8s-gateway --version 3.7.1
- task fmt
- task lint