### PR TITLE
Add metrics-server to kube-system

### DIFF
--- a/apps/kube-system/metrics-server/app.yaml
+++ b/apps/kube-system/metrics-server/app.yaml
@@ -1,0 +1,7 @@
+---
+chart:
+  repo: https://kubernetes-sigs.github.io/metrics-server
+  name: metrics-server
+  version: 3.13.1
+sync:
+  wave: "-3"

--- a/apps/kube-system/metrics-server/values.yaml
+++ b/apps/kube-system/metrics-server/values.yaml
@@ -1,0 +1,7 @@
+---
+fullnameOverride: metrics-server
+replicas: 1
+updateStrategy:
+  type: Recreate
+args:
+  - --kubelet-insecure-tls


### PR DESCRIPTION
## Summary
- Add a new `metrics-server` app under `apps/kube-system`
- Pin the chart version and set GitOps sync wave to `-3`
- Configure a single replica with `Recreate` update strategy and kubelet insecure TLS args

## Testing
- Not run (not requested)