### PR TITLE
fix(home-automation): allow OTBR device access

### DIFF
--- a/apps/home-automation/otbr/values.yaml
+++ b/apps/home-automation/otbr/values.yaml
@@ -40,12 +40,7 @@ controllers:
           readiness:
             enabled: true
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-              - NET_ADMIN
-            drop:
-              - ALL
+          privileged: true
 
 service:
   main:

--- a/policy/kubernetes/workload_security.rego
+++ b/policy/kubernetes/workload_security.rego
@@ -25,6 +25,7 @@ security_context_exempt_image_prefixes := [
   "ghcr.io/koush/scrypted:",
   "ghcr.io/paperless-ngx/paperless-ngx:",
   "icereed/paperless-gpt:",
+  "openthread/border-router:",
   "qmcgaw/gluetun:",
   "restic/rest-server:",
   "restic/restic:",


### PR DESCRIPTION
## Summary
- Run OTBR privileged so the container runtime allows opening the mounted `/dev/ttyUSB0` RCP char device.
- Scope the rendered workload policy exemption to `openthread/border-router:`.

## Root Cause
- OTBR rendered with `/dev/ttyUSB0` mounted and the correct radio URL.
- The pod logs failed at `open uart failed: Operation not permitted`, which points to runtime device access rather than missing device, wrong baud rate, or firmware.

## Test Plan
- [x] `helm template otbr oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.1 -n home-automation -f apps/home-automation/otbr/values.yaml`
- [x] `task fmt && task lint`