### PR TITLE
fix(home-automation): pin Matter Server primary interface

### DIFF
--- a/apps/home-automation/matter-server/values.yaml
+++ b/apps/home-automation/matter-server/values.yaml
@@ -21,6 +21,13 @@ controllers:
         image:
           repository: ghcr.io/matter-js/python-matter-server
           tag: 8.1.2
+        args:
+          - --storage-path
+          - /data
+          - --paa-root-cert-dir
+          - /data/credentials
+          - --primary-interface
+          - br0
         ports:
           - name: ws
             containerPort: 5580


### PR DESCRIPTION
## Summary
- preserve Matter Server storage and certificate arguments explicitly
- set `--primary-interface br0` so Matter link-local and mDNS behavior targets the host bridge used by OTBR

## Verification
- `helm template matter-server oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.1 -n home-automation -f apps/home-automation/matter-server/values.yaml`
- `task fmt`
- `task lint`