### PR TITLE
feat(home-automation): switch Matter Server to matter.js

### DIFF
--- a/apps/home-automation/matter-server/values.yaml
+++ b/apps/home-automation/matter-server/values.yaml
@@ -19,15 +19,12 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/matter-js/python-matter-server
-          tag: 8.1.2
-        args:
-          - --storage-path
-          - /data
-          - --paa-root-cert-dir
-          - /data/credentials
-          - --primary-interface
-          - br0
+          repository: ghcr.io/matter-js/matterjs-server
+          tag: 1.1.0
+        env:
+          PORT: "5580"
+          PRIMARY_INTERFACE: br0
+          STORAGE_PATH: /data
         ports:
           - name: ws
             containerPort: 5580
@@ -35,6 +32,9 @@ controllers:
         probes:
           startup:
             enabled: true
+            spec:
+              failureThreshold: 36
+              periodSeconds: 10
           liveness:
             enabled: true
           readiness:


### PR DESCRIPTION
## Summary
- switch `matter-server` from `ghcr.io/matter-js/python-matter-server:8.1.2` to `ghcr.io/matter-js/matterjs-server:1.1.0`
- keep the existing app name, service, PVC, host networking, and Home Assistant WebSocket URL unchanged
- configure matter.js with `STORAGE_PATH=/data`, `PRIMARY_INTERFACE=br0`, and `PORT=5580`
- skip the one-time in-pod backup container because restore is covered by the operator backup path

## Verification
- `helm template matter-server oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.1 -n home-automation -f apps/home-automation/matter-server/values.yaml`
- `task fmt`
- `git diff --check`
- `task lint`