### PR TITLE
Fix monitoring stack sync namespace

### DIFF
--- a/apps/platform-system/kube-prometheus-stack/values.yaml
+++ b/apps/platform-system/kube-prometheus-stack/values.yaml
@@ -15,6 +15,8 @@ kubeProxy:
   enabled: false
 kubeScheduler:
   enabled: false
+coreDns:
+  enabled: false
 
 alertmanager:
   alertmanagerSpec:


### PR DESCRIPTION
## Summary
- disable kube-prometheus-stack CoreDNS helper resources so the app stays within the platform-system AppProject destination

## Verification
- helm template kube-prometheus-stack with chart 87.3.0 and repo values renders no kube-system resources
- task fmt:check
- task lint:kubernetes