### PR TITLE
Disable Grafana plugin preinstall updates

### DIFF
--- a/apps/platform-system/kube-prometheus-stack/values.yaml
+++ b/apps/platform-system/kube-prometheus-stack/values.yaml
@@ -47,6 +47,9 @@ grafana:
     auth.anonymous:
       enabled: true
       org_role: Viewer
+    plugins:
+      preinstall_auto_update: false
+      preinstall_disabled: true
     server:
       root_url: https://grafana.edgard.org
   persistence:


### PR DESCRIPTION
## Summary
- disable Grafana plugin preinstall and automatic preinstall updates
- avoid startup permission errors from Grafana trying to update bundled plugins under the non-root runtime

## Verification
- helm template kube-prometheus-stack renders the Grafana config with the plugin settings
- task fmt:check
- task lint:kubernetes
- task lint