### PR TITLE
Improve blackbox timeline readability

### DIFF
--- a/apps/platform-system/prometheus-blackbox-exporter/manifests/prometheus-blackbox-exporter-dashboard.configmap.yaml
+++ b/apps/platform-system/prometheus-blackbox-exporter/manifests/prometheus-blackbox-exporter-dashboard.configmap.yaml
@@ -994,8 +994,8 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 12,
+            "h": 12,
+            "w": 24,
             "x": 0,
             "y": 22
           },
@@ -1022,12 +1022,12 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_success{group=~\"$group\", instance=~\"$instance\"}",
+              "expr": "probe_success{group=\"routed\", instance=~\"$instance\"}",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
           ],
-          "title": "Failure timeline",
+          "title": "Routed failure timeline",
           "type": "state-timeline"
         },
         {
@@ -1103,8 +1103,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 22
+            "x": 0,
+            "y": 34
           },
           "id": 10,
           "options": {
@@ -1219,9 +1219,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 30
+            "w": 12,
+            "x": 12,
+            "y": 34
           },
           "id": 11,
           "options": {
@@ -1261,7 +1261,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 38
+            "y": 42
           },
           "id": 12,
           "panels": [],
@@ -1413,7 +1413,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 43
           },
           "id": 13,
           "options": {
@@ -1599,7 +1599,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 43
           },
           "id": 14,
           "options": {
@@ -1736,7 +1736,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 50
           },
           "id": 15,
           "options": {
@@ -1830,7 +1830,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 50
           },
           "id": 16,
           "options": {
@@ -1870,7 +1870,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 53
+            "y": 57
           },
           "id": 17,
           "panels": [],
@@ -1937,7 +1937,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 58
           },
           "id": 18,
           "options": {
@@ -2031,7 +2031,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 58
           },
           "id": 19,
           "options": {


### PR DESCRIPTION
## Summary
- make the routed failure timeline full width and taller so labels do not overlap
- scope the timeline to routed HTTP probes, since DNS and ICMP already have dedicated panels
- move slowest targets and latency below the timeline to preserve triage context

## Tests
- task fmt:check
- task lint:kubernetes
- parsed dashboard JSON from ConfigMap and verified timeline grid/query settings