### PR TITLE
Make blackbox dashboard sections consistent

### DIFF
--- a/apps/platform-system/prometheus-blackbox-exporter/manifests/prometheus-blackbox-exporter-dashboard.configmap.yaml
+++ b/apps/platform-system/prometheus-blackbox-exporter/manifests/prometheus-blackbox-exporter-dashboard.configmap.yaml
@@ -123,7 +123,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "min(probe_success{group=~\"$group\", instance=~\"$instance\"})",
+              "expr": "min(probe_success)",
               "legendFormat": "probe success",
               "refId": "A"
             }
@@ -187,7 +187,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum(probe_success{group=~\"$group\", instance=~\"$instance\"} == bool 0)",
+              "expr": "sum(probe_success == bool 0)",
               "legendFormat": "failing",
               "refId": "A"
             }
@@ -255,7 +255,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "avg(avg_over_time(probe_success{group=~\"$group\", instance=~\"$instance\"}[$__range])) * 100",
+              "expr": "avg(avg_over_time(probe_success[$__range])) * 100",
               "legendFormat": "uptime",
               "refId": "A"
             }
@@ -323,7 +323,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "min((probe_ssl_earliest_cert_expiry{group=\"routed\", instance=~\"$instance\"} - time()) / 86400)",
+              "expr": "min((probe_ssl_earliest_cert_expiry{group=\"routed\"} - time()) / 86400)",
               "legendFormat": "days",
               "refId": "A"
             }
@@ -467,7 +467,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "count by (group) (probe_success{group=~\"$group\", instance=~\"$instance\"})",
+              "expr": "count by (group) (probe_success)",
               "format": "table",
               "instant": true,
               "legendFormat": "total",
@@ -478,7 +478,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum by (group) (probe_success{group=~\"$group\", instance=~\"$instance\"} == bool 0)",
+              "expr": "sum by (group) (probe_success == bool 0)",
               "format": "table",
               "instant": true,
               "legendFormat": "failing",
@@ -489,7 +489,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "avg by (group) (avg_over_time(probe_success{group=~\"$group\", instance=~\"$instance\"}[$__range])) * 100",
+              "expr": "avg by (group) (avg_over_time(probe_success[$__range])) * 100",
               "format": "table",
               "instant": true,
               "legendFormat": "uptime",
@@ -500,7 +500,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "max by (group) (probe_duration_seconds{group=~\"$group\", instance=~\"$instance\"})",
+              "expr": "max by (group) (probe_duration_seconds)",
               "format": "table",
               "instant": true,
               "legendFormat": "max duration",
@@ -546,12 +546,411 @@ data:
           "type": "table"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Health"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "0": {
+                            "text": "Failing",
+                            "color": "red"
+                          },
+                          "1": {
+                            "text": "Healthy",
+                            "color": "green"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "basic",
+                      "type": "color-background"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "green",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 3
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 20,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "probe_success == 0",
+              "refId": "A",
+              "format": "table",
+              "instant": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "probe_duration_seconds and on(group, instance) (probe_success == 0)",
+              "refId": "B",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "title": "Current failing targets",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "instance",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true,
+                  "__name__": true,
+                  "endpoint": true,
+                  "job": true,
+                  "namespace": true,
+                  "pod": true,
+                  "service": true
+                },
+                "indexByName": {
+                  "group": 0,
+                  "instance": 1,
+                  "Value #A": 2,
+                  "Value #B": 3
+                },
+                "renameByName": {
+                  "group": "Group",
+                  "instance": "Target",
+                  "Value #A": "Health",
+                  "Value #B": "Duration"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 3
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "basic",
+                      "type": "color-background"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 0.25
+                        },
+                        {
+                          "color": "red",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 10,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "topk(10, probe_duration_seconds)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Slowest targets",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "endpoint": true,
+                  "job": true,
+                  "namespace": true,
+                  "pod": true,
+                  "service": true
+                },
+                "indexByName": {
+                  "group": 0,
+                  "instance": 1,
+                  "Value": 2
+                },
+                "renameByName": {
+                  "group": "Group",
+                  "instance": "Instance",
+                  "Value": "Duration"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (group) (probe_duration_seconds)",
+              "legendFormat": "{{ group }} max",
+              "refId": "A"
+            }
+          ],
+          "title": "Latency by group",
+          "type": "timeseries"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 11
+            "y": 26
           },
           "id": 7,
           "panels": [],
@@ -809,7 +1208,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 12
+            "y": 27
           },
           "id": 8,
           "options": {
@@ -831,7 +1230,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_success{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_success{group=\"routed\"}",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -841,7 +1240,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_http_status_code{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_http_status_code{group=\"routed\"}",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -851,7 +1250,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_http_version{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_http_version{group=\"routed\"}",
               "format": "table",
               "instant": true,
               "refId": "C"
@@ -861,7 +1260,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_http_redirects{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_http_redirects{group=\"routed\"}",
               "format": "table",
               "instant": true,
               "refId": "D"
@@ -871,7 +1270,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_http_ssl{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_http_ssl{group=\"routed\"}",
               "format": "table",
               "instant": true,
               "refId": "E"
@@ -881,7 +1280,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "(probe_ssl_earliest_cert_expiry{group=\"routed\", instance=~\"$instance\"} - time()) / 86400",
+              "expr": "(probe_ssl_earliest_cert_expiry{group=\"routed\"} - time()) / 86400",
               "format": "table",
               "instant": true,
               "refId": "F"
@@ -891,7 +1290,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_duration_seconds{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_duration_seconds{group=\"routed\"}",
               "format": "table",
               "instant": true,
               "refId": "G"
@@ -997,7 +1396,7 @@ data:
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 22
+            "y": 37
           },
           "id": 9,
           "options": {
@@ -1022,7 +1421,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_success{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_success{group=\"routed\"}",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -1058,16 +1457,16 @@ data:
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Duration"
+                  "options": "TLS days"
                 },
                 "properties": [
                   {
                     "id": "unit",
-                    "value": "s"
+                    "value": "d"
                   },
                   {
                     "id": "decimals",
-                    "value": 3
+                    "value": 0
                   },
                   {
                     "id": "custom.cellOptions",
@@ -1082,16 +1481,16 @@ data:
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "green",
+                          "color": "red",
                           "value": null
                         },
                         {
                           "color": "orange",
-                          "value": 0.25
+                          "value": 7
                         },
                         {
-                          "color": "red",
-                          "value": 1
+                          "color": "green",
+                          "value": 14
                         }
                       ]
                     }
@@ -1101,12 +1500,12 @@ data:
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 12,
+            "h": 7,
+            "w": 24,
             "x": 0,
-            "y": 34
+            "y": 49
           },
-          "id": 10,
+          "id": 21,
           "options": {
             "cellHeight": "sm",
             "footer": {
@@ -1126,13 +1525,13 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "topk(10, probe_duration_seconds{group=~\"$group\", instance=~\"$instance\"})",
+              "expr": "(probe_ssl_earliest_cert_expiry{group=\"routed\"} - time()) / 86400",
+              "refId": "A",
               "format": "table",
-              "instant": true,
-              "refId": "A"
+              "instant": true
             }
           ],
-          "title": "Slowest targets",
+          "title": "TLS expiry",
           "transformations": [
             {
               "id": "organize",
@@ -1141,20 +1540,19 @@ data:
                   "Time": true,
                   "__name__": true,
                   "endpoint": true,
+                  "group": true,
                   "job": true,
                   "namespace": true,
                   "pod": true,
                   "service": true
                 },
                 "indexByName": {
-                  "group": 0,
-                  "instance": 1,
-                  "Value": 2
+                  "instance": 0,
+                  "Value": 1
                 },
                 "renameByName": {
-                  "group": "Group",
-                  "instance": "Instance",
-                  "Value": "Duration"
+                  "instance": "Target",
+                  "Value": "TLS days"
                 }
               }
             }
@@ -1162,110 +1560,16 @@ data:
           "type": "table"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 34
-          },
-          "id": 11,
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "pluginVersion": "11.6.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "max by (group) (probe_duration_seconds{group=~\"$group\", instance=~\"$instance\"})",
-              "legendFormat": "{{ group }} max",
-              "refId": "A"
-            }
-          ],
-          "title": "Latency by group",
-          "type": "timeseries"
-        },
-        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 56
           },
           "id": 12,
           "panels": [],
-          "title": "DNS + Connectivity",
+          "title": "DNS",
           "type": "row"
         },
         {
@@ -1413,7 +1717,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 57
           },
           "id": 13,
           "options": {
@@ -1435,7 +1739,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_success{group=\"dns\", instance=~\"$instance\"}",
+              "expr": "probe_success{group=\"dns\"}",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1445,7 +1749,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_dns_query_succeeded{group=\"dns\", instance=~\"$instance\"}",
+              "expr": "probe_dns_query_succeeded{group=\"dns\"}",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1455,7 +1759,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_dns_duration_seconds{group=\"dns\", instance=~\"$instance\"}",
+              "expr": "probe_dns_duration_seconds{group=\"dns\"}",
               "format": "table",
               "instant": true,
               "refId": "C"
@@ -1502,6 +1806,113 @@ data:
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 57
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "probe_dns_duration_seconds{group=\"dns\"}",
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "title": "DNS duration",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 64
+          },
+          "id": 22,
+          "panels": [],
+          "title": "Connectivity",
+          "type": "row"
         },
         {
           "datasource": {
@@ -1598,8 +2009,8 @@ data:
           "gridPos": {
             "h": 7,
             "w": 12,
-            "x": 12,
-            "y": 43
+            "x": 0,
+            "y": 65
           },
           "id": 14,
           "options": {
@@ -1621,7 +2032,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_success{group=\"connectivity\", instance=~\"$instance\"}",
+              "expr": "probe_success{group=\"connectivity\"}",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1631,7 +2042,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_icmp_duration_seconds{group=\"connectivity\", instance=~\"$instance\"}",
+              "expr": "probe_icmp_duration_seconds{group=\"connectivity\"}",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1735,102 +2146,8 @@ data:
           "gridPos": {
             "h": 7,
             "w": 12,
-            "x": 0,
-            "y": 50
-          },
-          "id": 15,
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "pluginVersion": "11.6.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "probe_dns_duration_seconds{group=\"dns\", instance=~\"$instance\"}",
-              "legendFormat": "{{ instance }}",
-              "refId": "A"
-            }
-          ],
-          "title": "DNS duration",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
             "x": 12,
-            "y": 50
+            "y": 65
           },
           "id": 16,
           "options": {
@@ -1856,7 +2173,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_icmp_duration_seconds{group=\"connectivity\", instance=~\"$instance\"}",
+              "expr": "probe_icmp_duration_seconds{group=\"connectivity\"}",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -1870,11 +2187,11 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 72
           },
           "id": 17,
           "panels": [],
-          "title": "Target Drilldown",
+          "title": "Selected HTTP Target",
           "type": "row"
         },
         {
@@ -1937,7 +2254,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 73
           },
           "id": 18,
           "options": {
@@ -1963,7 +2280,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_http_duration_seconds{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_http_duration_seconds{group=\"routed\", instance=\"$routed_instance\"}",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -2031,7 +2348,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 73
           },
           "id": 19,
           "options": {
@@ -2056,7 +2373,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "probe_http_status_code{group=\"routed\", instance=~\"$instance\"}",
+              "expr": "probe_http_status_code{group=\"routed\", instance=\"$routed_instance\"}",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -2076,50 +2393,23 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
-              "text": "All",
-              "value": "$__all"
+              "selected": false,
+              "text": "https://grafana.edgard.org",
+              "value": "https://grafana.edgard.org"
             },
             "datasource": {
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "definition": "label_values(probe_success, group)",
+            "definition": "label_values(probe_success{group=\"routed\"}, instance)",
             "hide": 0,
-            "includeAll": true,
-            "label": "Group",
-            "multi": true,
-            "name": "group",
+            "includeAll": false,
+            "label": "HTTP target",
+            "multi": false,
+            "name": "routed_instance",
             "options": [],
             "query": {
-              "query": "label_values(probe_success, group)",
-              "refId": "PrometheusVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "type": "query"
-          },
-          {
-            "current": {
-              "selected": true,
-              "text": "All",
-              "value": "$__all"
-            },
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "definition": "label_values(probe_success{group=~\"$group\"}, instance)",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Instance",
-            "multi": true,
-            "name": "instance",
-            "options": [],
-            "query": {
-              "query": "label_values(probe_success{group=~\"$group\"}, instance)",
+              "query": "label_values(probe_success{group=\"routed\"}, instance)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,


### PR DESCRIPTION
## Summary
- remove the global group selector and keep one routed HTTP drilldown target selector
- make overview, routed HTTP, DNS, and connectivity sections use fixed query scopes
- move cross-group slowest/latency panels into overview context and add current failures/TLS expiry tables

## Tests
- task fmt:check
- task lint:kubernetes
- parsed dashboard JSON and verified panel/variable structure
- validated 25 unique dashboard PromQL expressions against live Prometheus