### PR TITLE
fix(paperless): allow gpt entrypoint setup

### DIFF
--- a/apps/selfhosted/paperless/values.yaml
+++ b/apps/selfhosted/paperless/values.yaml
@@ -173,6 +173,10 @@ controllers:
           capabilities:
             drop:
               - ALL
+            add:
+              - CHOWN
+              - SETUID
+              - SETGID
   gotenberg:
     type: deployment
     replicas: 1

--- a/policy/kubernetes/workload_security.rego
+++ b/policy/kubernetes/workload_security.rego
@@ -30,6 +30,8 @@ security_context_exempt_image_prefixes := [
   "ghcr.io/tailscale/tailscale:",
 ]
 
+paperless_gpt_required_capabilities := {"CHOWN", "SETUID", "SETGID"}
+
 deny contains msg if {
   is_app_template_workload
   object.get(input.spec, "replicas", 1) != 1
@@ -64,6 +66,15 @@ deny contains msg if {
   not exempt_root_run(container)
   not effective_run_as_non_root(container)
   msg := sprintf("%s/%s container %s must run as non-root", [input.kind, input.metadata.name, container.name])
+}
+
+deny contains msg if {
+  is_app_template_workload
+  some container in workload_containers
+  image_matches_prefix(object.get(container, "image", ""), ["icereed/paperless-gpt:"])
+  missing := paperless_gpt_required_capabilities - {cap | cap := object.get(object.get(object.get(container, "securityContext", {}), "capabilities", {}), "add", [])[_]}
+  count(missing) > 0
+  msg := sprintf("%s/%s container %s must add capabilities required by the paperless-gpt entrypoint: %v", [input.kind, input.metadata.name, container.name, missing])
 }
 
 is_app_template_workload if {

--- a/policy/kubernetes/workload_security_test.rego
+++ b/policy/kubernetes/workload_security_test.rego
@@ -50,3 +50,16 @@ test_tailscale_is_exempt_from_container_security_rules if {
   results := deny with input as doc
   count(results) == 0
 }
+
+test_paperless_gpt_requires_entrypoint_capabilities if {
+  doc := object.union(base_deployment, {"spec": object.union(base_deployment.spec, {"template": {"spec": {"securityContext": {"runAsNonRoot": false}, "containers": [{
+    "name": "app",
+    "image": "icereed/paperless-gpt:v0.26.0",
+    "securityContext": {
+      "allowPrivilegeEscalation": false,
+      "capabilities": {"drop": ["ALL"]},
+    },
+  }]}}})})
+  results := deny with input as doc
+  count(results) == 1
+}


### PR DESCRIPTION
## Summary
- allow the paperless-gpt container to add CHOWN, SETUID, and SETGID while still dropping ALL by default
- add a rendered policy guard so future paperless-gpt renders keep the required entrypoint capabilities

## Verification
- task fmt
- task lint:kubernetes
- task lint