### PR TITLE
fix(monitoring): make Telegram alerts readable

### DIFF
--- a/apps/platform-system/kube-prometheus-stack/manifests/kube-prometheus-stack-alertmanager-config.externalsecret.yaml
+++ b/apps/platform-system/kube-prometheus-stack/manifests/kube-prometheus-stack-alertmanager-config.externalsecret.yaml
@@ -42,7 +42,45 @@ spec:
               telegram_configs:
                 - bot_token: "{{ .telegram_bot_token }}"
                   chat_id: {{ .telegram_chat_id }}
+                  parse_mode: HTML
                   send_resolved: true
+                  message: |-
+                    {{ `{{ if eq .Status "firing" -}}` }}
+                    <b>FIRING: {{ `{{ .CommonLabels.alertname | html }}` }}{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}){{ `{{ end }}` }}</b>
+                    {{ `{{- else -}}` }}
+                    <b>RESOLVED: {{ `{{ .CommonLabels.alertname | html }}` }}{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}){{ `{{ end }}` }}</b>
+                    {{ `{{- end }}` }}
+                    {{ `{{ range .Alerts }}` }}
+
+                    {{ `{{- with .Annotations.summary }}` }}
+                    {{ `{{ . | html }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- with .Annotations.description }}` }}
+                    {{ `{{ . | html }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- with .Labels.severity }}` }}
+                    Severity: {{ `{{ . | html }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- with .Labels.namespace }}` }}
+                    Namespace: {{ `{{ . | html }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- if .Labels.name }}` }}
+                    Target: {{ `{{ .Labels.name | html }}` }}
+                    {{ `{{- else if .Labels.pod }}` }}
+                    Target: {{ `{{ .Labels.pod | html }}` }}
+                    {{ `{{- else if .Labels.job_name }}` }}
+                    Target: {{ `{{ .Labels.job_name | html }}` }}
+                    {{ `{{- else if .Labels.instance }}` }}
+                    Target: {{ `{{ .Labels.instance | html }}` }}
+                    {{ `{{- else if .Labels.service }}` }}
+                    Target: {{ `{{ .Labels.service | html }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- with .Annotations.runbook_url }}` }}
+                    Runbook: {{ `{{ . | html }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{ end }}` }}
+
+                    Grafana: https://grafana.edgard.org/explore
   data:
     - secretKey: telegram_bot_token
       remoteRef:


### PR DESCRIPTION
## Summary
- customize Alertmanager Telegram notifications with a compact HTML message
- keep Prometheus and Alertmanager internal while linking alerts to Grafana Explore
- escape Alertmanager templates through the External Secrets render layer

## Test Plan
- [x] `task fmt:check`
- [x] `task lint:kubernetes`
- [x] render `alertmanager.yaml` from the ExternalSecret template with placeholder Telegram secrets
- [x] `amtool check-config /dev/stdin` using the running Alertmanager pod
