### PR TITLE
fix(renovate): manage restic restore image

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -111,6 +111,18 @@
       ],
       datasourceTemplate: "docker",
     },
+
+    // Restic restore job image in Ansible role defaults
+    {
+      customType: "regex",
+      description: "Restic restore image in Ansible defaults",
+      managerFilePatterns: [
+        "/^ansible\\/roles\\/restic\\/defaults\\/main\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*restic_restore_image:\\s*[^:\\s]+:(?<currentValue>[^\\s]+)",
+      ],
+    },
   ],
 
   // === Package Rules ===

--- a/ansible/roles/restic/defaults/main.yml
+++ b/ansible/roles/restic/defaults/main.yml
@@ -11,7 +11,8 @@ restic_restore_repo_url: rest:http://restic.selfhosted.svc.cluster.local:8000/
 restic_restore_rest_username: restic
 restic_restore_credentials_secret: restic-credentials
 restic_restore_credentials_key: RESTIC_PASSWORD
-restic_restore_image: restic/restic:0.19.0
+# renovate: datasource=docker depName=restic/restic
+restic_restore_image: restic/restic:0.19.1
 restic_restore_snapshot_root: /data/appdata
 restic_restore_snapshot_host: homelab
 restic_restore_snapshot_tag: appdata

--- a/ansible/tests/native-conventions.yml
+++ b/ansible/tests/native-conventions.yml
@@ -122,6 +122,25 @@
           - "'k8s_version' in (conventions_inventory_vars.content | b64decode)"
           - "'K8S_VERSION' in (conventions_inventory_vars.content | b64decode)"
 
+    - name: Read Renovate config
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/.renovaterc.json5"
+      register: conventions_renovate_config
+
+    - name: Read restic role defaults
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/ansible/roles/restic/defaults/main.yml"
+      register: conventions_restic_defaults
+
+    - name: Assert restic restore image is Renovate-managed
+      ansible.builtin.assert:
+        that:
+          - "'# renovate: datasource=docker depName=restic/restic' in (conventions_restic_defaults.content | b64decode)"
+          - "'restic_restore_image: restic/restic:' in (conventions_restic_defaults.content | b64decode)"
+          - "'Restic restore image in Ansible defaults' in (conventions_renovate_config.content | b64decode)"
+          - "'restic_restore_image' in (conventions_renovate_config.content | b64decode)"
+        fail_msg: "The restic restore image default must remain managed by Renovate."
+
     - name: Find Ansible task files
       ansible.builtin.find:
         paths:


### PR DESCRIPTION
## Summary
- add Renovate coverage for the Ansible restic restore image default
- bump the restore job image to the current managed restic tag
- add an Ansible contract so the default stays Renovate-managed

## Verification
- renovate-config-validator .renovaterc.json5
- renovate --platform=local --dry-run=lookup
- .venv/bin/ansible-playbook ansible/tests/native-conventions.yml
- task lint:ansible
- git diff --check