### PR TITLE
fix(monitoring): improve Telegram alert format

### DIFF
--- a/ansible/tests/native-conventions.yml
+++ b/ansible/tests/native-conventions.yml
@@ -198,6 +198,17 @@
         fail_msg: "Alertmanager warning route does not include observability alert {{ item }}"
       loop: "{{ conventions_observability_warning_alerts }}"
 
+    - name: Assert Telegram alerts use the Home Ops message format
+      ansible.builtin.assert:
+        that:
+          - "'🏠 Home Ops · Monitoring' in (conventions_alertmanager_config.content | b64decode)"
+          - "'<blockquote>' in (conventions_alertmanager_config.content | b64decode)"
+          - "'.Alerts.Firing' in (conventions_alertmanager_config.content | b64decode)"
+          - "'.Alerts.Resolved' in (conventions_alertmanager_config.content | b64decode)"
+          - "'Grafana: https://grafana.edgard.org/explore' not in (conventions_alertmanager_config.content | b64decode)"
+          - "'.GeneratorURL' not in (conventions_alertmanager_config.content | b64decode)"
+        fail_msg: "Telegram alerts do not use the expected Home Ops message format"
+
     - name: Read Argo CD refresh role
       ansible.builtin.slurp:
         src: "{{ conventions_repo_root }}/ansible/roles/argocd/tasks/refresh.yml"

--- a/apps/platform-system/kube-prometheus-stack/manifests/kube-prometheus-stack-alertmanager-config.externalsecret.yaml
+++ b/apps/platform-system/kube-prometheus-stack/manifests/kube-prometheus-stack-alertmanager-config.externalsecret.yaml
@@ -49,42 +49,58 @@ spec:
                   parse_mode: HTML
                   send_resolved: true
                   message: |-
-                    {{ `{{ if eq .Status "firing" -}}` }}
-                    <b>FIRING: {{ `{{ .CommonLabels.alertname | html }}` }}{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}){{ `{{ end }}` }}</b>
-                    {{ `{{- else -}}` }}
-                    <b>RESOLVED: {{ `{{ .CommonLabels.alertname | html }}` }}{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}){{ `{{ end }}` }}</b>
-                    {{ `{{- end }}` }}
-                    {{ `{{ range .Alerts }}` }}
-
+                    {{ `{{ define "homeops.telegram.alert" -}}` }}
                     {{ `{{- with .Annotations.summary }}` }}
-                    {{ `{{ . | html }}` }}
+                    <b>{{ `{{ . | html }}` }}</b>
                     {{ `{{- end }}` }}
                     {{ `{{- with .Annotations.description }}` }}
-                    {{ `{{ . | html }}` }}
+                    <blockquote>{{ `{{ . | html }}` }}</blockquote>
                     {{ `{{- end }}` }}
                     {{ `{{- with .Labels.severity }}` }}
-                    Severity: {{ `{{ . | html }}` }}
+                    <b>Severity:</b> {{ `{{ . | title | html }}` }}
                     {{ `{{- end }}` }}
                     {{ `{{- with .Labels.namespace }}` }}
-                    Namespace: {{ `{{ . | html }}` }}
+                    <b>Namespace:</b> <code>{{ `{{ . | html }}` }}</code>
                     {{ `{{- end }}` }}
                     {{ `{{- if .Labels.name }}` }}
-                    Target: {{ `{{ .Labels.name | html }}` }}
+                    <b>Target:</b> <code>{{ `{{ .Labels.name | html }}` }}</code>
                     {{ `{{- else if .Labels.pod }}` }}
-                    Target: {{ `{{ .Labels.pod | html }}` }}
+                    <b>Target:</b> <code>{{ `{{ .Labels.pod | html }}` }}</code>
                     {{ `{{- else if .Labels.job_name }}` }}
-                    Target: {{ `{{ .Labels.job_name | html }}` }}
+                    <b>Target:</b> <code>{{ `{{ .Labels.job_name | html }}` }}</code>
                     {{ `{{- else if .Labels.instance }}` }}
-                    Target: {{ `{{ .Labels.instance | html }}` }}
+                    <b>Target:</b> <code>{{ `{{ .Labels.instance | html }}` }}</code>
                     {{ `{{- else if .Labels.service }}` }}
-                    Target: {{ `{{ .Labels.service | html }}` }}
+                    <b>Target:</b> <code>{{ `{{ .Labels.service | html }}` }}</code>
                     {{ `{{- end }}` }}
                     {{ `{{- with .Annotations.runbook_url }}` }}
-                    Runbook: {{ `{{ . | html }}` }}
+                    📖 <a href="{{ `{{ . | html }}` }}">Runbook</a>
                     {{ `{{- end }}` }}
-                    {{ `{{ end }}` }}
+                    {{ `{{- end -}}` }}
+                    <b>🏠 Home Ops · Monitoring</b>
 
-                    Grafana: https://grafana.edgard.org/explore
+                    {{ `{{- if gt (len .Alerts.Firing) 0 }}` }}
+
+                    {{ `{{ if eq .CommonLabels.severity "critical" }}` }}🔴{{ `{{ else if eq .CommonLabels.severity "warning" }}` }}⚠️{{ `{{ else }}` }}🔥{{ `{{ end }}` }} <b>FIRING · {{ `{{ .CommonLabels.alertname | html }}` }}{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}){{ `{{ end }}` }}</b>
+                    {{ `{{- range $index, $alert := .Alerts.Firing }}` }}
+                    {{ `{{- if $index }}` }}
+
+                    ────────
+                    {{ `{{- end }}` }}
+                    {{ `{{ template "homeops.telegram.alert" $alert }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- if gt (len .Alerts.Resolved) 0 }}` }}
+
+                    ✅ <b>RESOLVED · {{ `{{ .CommonLabels.alertname | html }}` }}{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}){{ `{{ end }}` }}</b>
+                    {{ `{{- range $index, $alert := .Alerts.Resolved }}` }}
+                    {{ `{{- if $index }}` }}
+
+                    ────────
+                    {{ `{{- end }}` }}
+                    {{ `{{ template "homeops.telegram.alert" $alert }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- end }}` }}
   data:
     - secretKey: telegram_bot_token
       remoteRef:


### PR DESCRIPTION
## Summary

- add a `Home Ops · Monitoring` header and severity-aware firing/resolved sections
- improve mobile readability with bold summaries, blockquoted descriptions, compact metadata, and grouped-alert dividers
- remove the permanent Grafana Explore link while preserving optional runbook links
- add an Ansible contract for the Telegram message shape

## Validation

- `task lint`
- rendered External Secrets and Alertmanager template layers with placeholder credentials
- `amtool check-config`
- `amtool template render` for critical, warning, fallback, resolved-only, mixed-state, grouped, runbook, and HTML-escaping cases
