### PR TITLE
Enable Changedetection AI summaries

### DIFF
--- a/ansible/tests/native-conventions.yml
+++ b/ansible/tests/native-conventions.yml
@@ -141,6 +141,29 @@
           - "'restic_restore_image' in (conventions_renovate_config.content | b64decode)"
         fail_msg: "The restic restore image default must remain managed by Renovate."
 
+    - name: Read Changedetection values
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/apps/selfhosted/changedetection/values.yaml"
+      register: conventions_changedetection_values
+
+    - name: Read Changedetection credentials ExternalSecret
+      ansible.builtin.slurp:
+        src: "{{ conventions_repo_root }}/apps/selfhosted/changedetection/manifests/changedetection-credentials.externalsecret.yaml"
+      register: conventions_changedetection_credentials
+
+    - name: Assert Changedetection AI summaries use the shared OpenAI credential
+      ansible.builtin.assert:
+        that:
+          - "'LLM_MODEL: gpt-5-mini' in (conventions_changedetection_values.content | b64decode)"
+          - '''LLM_MAX_INPUT_CHARS: "20000"'' in (conventions_changedetection_values.content | b64decode)'
+          - "'LLM_API_BASE:' not in (conventions_changedetection_values.content | b64decode)"
+          - "'LLM_FEATURES_DISABLED:' not in (conventions_changedetection_values.content | b64decode)"
+          - "'name: changedetection-credentials' in (conventions_changedetection_values.content | b64decode)"
+          - "'LLM_API_KEY:' in (conventions_changedetection_credentials.content | b64decode)"
+          - "'secretKey: openai_api_key' in (conventions_changedetection_credentials.content | b64decode)"
+          - "'key: openai_api_key' in (conventions_changedetection_credentials.content | b64decode)"
+        fail_msg: "Changedetection AI summary configuration must use GPT-5 mini and the shared OpenAI credential."
+
     - name: Find Ansible task files
       ansible.builtin.find:
         paths:

--- a/apps/selfhosted/changedetection/manifests/changedetection-credentials.externalsecret.yaml
+++ b/apps/selfhosted/changedetection/manifests/changedetection-credentials.externalsecret.yaml
@@ -17,10 +17,14 @@ spec:
       data:
         CD_IO_API_KEY: "{{ .changedetection_api_key }}"
         CD_IO_NOTIFICATION_URL: "tgram://{{ .telegram_bot_token }}/{{ .telegram_chat_id }}/"
+        LLM_API_KEY: "{{ .openai_api_key }}"
   data:
     - secretKey: changedetection_api_key
       remoteRef:
         key: changedetection_api_key
+    - secretKey: openai_api_key
+      remoteRef:
+        key: openai_api_key
     - secretKey: telegram_bot_token
       remoteRef:
         key: telegram_bot_token

--- a/apps/selfhosted/changedetection/values.yaml
+++ b/apps/selfhosted/changedetection/values.yaml
@@ -26,6 +26,8 @@ controllers:
           FETCH_WORKERS: "10"
           PLAYWRIGHT_DRIVER_URL: ws://127.0.0.1:3000
           DISABLE_VERSION_CHECK: "true"
+          LLM_MODEL: gpt-5-mini
+          LLM_MAX_INPUT_CHARS: "20000"
         envFrom:
           - secretRef:
               name: changedetection-credentials


### PR DESCRIPTION
## What changed

- configure Changedetection to summarize future detected changes with `gpt-5-mini`
- reuse the existing Bitwarden-backed `openai_api_key` through External Secrets
- cap summary inputs at 20,000 characters
- add a regression contract for the model, input limit, enabled state, and secret wiring

## Impact

No workloads, routes, storage, or watches are added. Changedetection currently has zero watches; future watch changes will use AI summaries while intent-based filtering remains opt-in.

## Validation

- demonstrated the new contract failing before configuration
- `task lint:ansible`
- `task fmt`
- `task lint`