### PR TITLE
fix(paperless): update to 3.0.2

### DIFF
--- a/apps/selfhosted/paperless/values.yaml
+++ b/apps/selfhosted/paperless/values.yaml
@@ -18,7 +18,7 @@ controllers:
       tesseract-langs:
         image:
           repository: ghcr.io/paperless-ngx/paperless-ngx
-          tag: 3.0.1
+          tag: 3.0.2
         securityContext:
           runAsUser: 0
           runAsGroup: 0
@@ -69,7 +69,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/paperless-ngx/paperless-ngx
-          tag: 3.0.1
+          tag: 3.0.2
         env:
           PAPERLESS_URL: https://paperless.edgard.org
           PAPERLESS_PORT: "8000"


### PR DESCRIPTION
## What changed

- Update the Paperless main container from 3.0.1 to 3.0.2.
- Update the matching Tesseract language init container to 3.0.2.

## Why

Paperless 3.0.1 introduced a broken migration dependency. After the previous 3.0.0 rollout recorded `paperless_mail.0002_optimize_integer_field_sizes`, 3.0.1 inserted `paperless_mail.0001_1_clamp_mailrule_maximum_age` as a new prerequisite. Django rejects that inconsistent migration history during startup, leaving `paperless-main` in `CrashLoopBackOff`.

Paperless 3.0.2 restores the released migration history and is the upstream-recommended recovery release.

## Impact

Argo CD will roll Paperless to 3.0.2 after this PR is merged. No manual database migration-table edits are required.

## Validation

- Red/green assertion for both Paperless image tags
- `task fmt`
- `task fmt:check`
- `task lint`
- `git diff --check`