### PR TITLE
Add lightweight Loki and Alloy logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 GitOps Talos Kubernetes homelab (single-node, local-only). Changes via PR only.
 **Tech**: Talos • K8s • Argo CD • Istio Gateway API • External Secrets (Bitwarden) •
-Prometheus/Grafana • Helm • Ansible • Terraform
+Prometheus/Grafana/Loki/Alloy • Helm • Ansible • Terraform
 
 ## Build & Test
 
@@ -37,7 +37,7 @@ terraform/               # Cloudflare/Tailscale infra
 ```
 
 **App Categories**:
-- platform-system: cert-manager, external-dns, external-secrets, gateway-api, istio, istio-base, kube-prometheus-stack, prometheus-blackbox-exporter, reloader, tailscale-router
+- platform-system: alloy, cert-manager, external-dns, external-secrets, gateway-api, istio, istio-base, kube-prometheus-stack, loki, prometheus-blackbox-exporter, reloader, tailscale-router
 - kube-system: coredns, k8s-gateway, k8tz, multus, nfs-provisioner
 - home-automation: homeassistant, scrypted
 - media: bazarr, flaresolverr, plex, plextraktsync, prowlarr, qbittorrent, radarr, recyclarr, sonarr, unpackerr
@@ -92,8 +92,20 @@ controllers:
   blackbox reachability tests.
 - Do not add `gethomepage.dev/*` or `gatus.home-operations.com/endpoint`
   annotations to routed apps.
-- Loki and Alloy are out of scope unless a future change explicitly adds log
-  aggregation.
+- Loki is a single monolithic StatefulSet with 30-day retention on a retained
+  30Gi `nfs-fast` claim. It is internal-only and has no HTTPRoute.
+- Alloy is a single non-root, checkpointed StatefulSet that collects pod
+  stdout/stderr and Kubernetes Events through the Kubernetes API and forwards
+  them to Loki. It has no HTTPRoute.
+- Pod log labels are `cluster`, `namespace`, `app`, and `container`; `pod`,
+  `node`, `container_image`, and `container_runtime` are structured metadata.
+  Events use `cluster`, `namespace`, `job="kubernetes/events"`, and the stable
+  Alloy instance label.
+- Grafana provisions Loki as a non-editable internal datasource. Anonymous
+  Viewer access means reachable LAN/Tailscale users can query collected logs.
+- Loki data and Alloy checkpoints are included in Restic backup and restore.
+- Talos host-service logs, external Loki access, log-derived alerts, and object
+  storage are out of scope.
 
 ### Storage
 - `nfs-fast`: `/mnt/spool/appdata` (default)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GitOps-driven Kubernetes homelab running on Talos Linux, managed by Argo CD with
 - Argo CD
 - Istio Gateway API
 - External Secrets with Bitwarden
-- Prometheus, Grafana, Alertmanager, and Blackbox Exporter
+- Prometheus, Grafana, Alertmanager, Blackbox Exporter, Loki, and Alloy
 - Helm
 - Ansible
 - Terraform

--- a/ansible/tests/observability-logging.yml
+++ b/ansible/tests/observability-logging.yml
@@ -1,0 +1,190 @@
+---
+- name: Validate lightweight logging observability contracts
+  hosts: localhost
+  gather_facts: false
+  vars:
+    observability_repo_root: "{{ playbook_dir }}/../.."
+
+  tasks:
+    - name: Read logging observability configuration
+      ansible.builtin.slurp:
+        src: "{{ observability_repo_root }}/{{ item }}"
+      loop:
+        - apps/platform-system/loki/app.yaml
+        - apps/platform-system/loki/values.yaml
+        - apps/platform-system/alloy/app.yaml
+        - apps/platform-system/alloy/values.yaml
+        - apps/platform-system/kube-prometheus-stack/values.yaml
+        - apps/selfhosted/restic/values.yaml
+        - ansible/roles/restic/defaults/main.yml
+      register: observability_logging_files
+
+    - name: Parse logging observability configuration
+      ansible.builtin.set_fact:
+        observability_loki_app: "{{ observability_logging_files.results[0].content | b64decode | from_yaml }}"
+        observability_loki_values: "{{ observability_logging_files.results[1].content | b64decode | from_yaml }}"
+        observability_alloy_app: "{{ observability_logging_files.results[2].content | b64decode | from_yaml }}"
+        observability_alloy_values: "{{ observability_logging_files.results[3].content | b64decode | from_yaml }}"
+        observability_monitoring_values: "{{ observability_logging_files.results[4].content | b64decode | from_yaml }}"
+        observability_restic_values: "{{ observability_logging_files.results[5].content | b64decode | from_yaml }}"
+        observability_restic_defaults: "{{ observability_logging_files.results[6].content | b64decode | from_yaml }}"
+
+    - name: Assert Loki uses the pinned monolithic NFS-backed topology
+      ansible.builtin.assert:
+        that:
+          - observability_loki_app.chart.repo == "https://grafana-community.github.io/helm-charts"
+          - observability_loki_app.chart.name == "loki"
+          - observability_loki_app.chart.version == "18.5.4"
+          - observability_loki_app.sync.wave == "0"
+          - observability_loki_values.deploymentMode == "Monolithic"
+          - observability_loki_values.loki.auth_enabled is false
+          - observability_loki_values.loki.commonConfig.replication_factor == 1
+          - observability_loki_values.loki.commonConfig.path_prefix == "/var/loki"
+          - observability_loki_values.loki.schemaConfig.configs[0].store == "tsdb"
+          - observability_loki_values.loki.schemaConfig.configs[0].schema == "v13"
+          - observability_loki_values.loki.schemaConfig.configs[0].object_store == "filesystem"
+          - observability_loki_values.loki.storage.type == "filesystem"
+          - observability_loki_values.loki.compactor.retention_enabled is true
+          - observability_loki_values.loki.limits_config.retention_period == "720h"
+          - observability_loki_values.loki.limits_config.reject_old_samples is true
+          - observability_loki_values.loki.limits_config.reject_old_samples_max_age == "168h"
+          - observability_loki_values.loki.limits_config.allow_structured_metadata is true
+          - observability_loki_values.loki.limits_config.discover_log_levels is true
+          - observability_loki_values.singleBinary.replicas == 1
+          - observability_loki_values.singleBinary.persistence.enabled is true
+          - observability_loki_values.singleBinary.persistence.enableStatefulSetAutoDeletePVC is true
+          - observability_loki_values.singleBinary.persistence.storageClass == "nfs-fast"
+          - observability_loki_values.singleBinary.persistence.size == "30Gi"
+          - observability_loki_values.singleBinary.persistence.whenDeleted == "Retain"
+          - observability_loki_values.singleBinary.persistence.whenScaled == "Retain"
+          - observability_loki_values.defaults.automountServiceAccountToken is false
+          - observability_loki_values.serviceAccount.automountServiceAccountToken is false
+          - "'resources' not in observability_loki_values.singleBinary"
+
+    - name: Assert Loki disables distributed and optional workloads
+      ansible.builtin.assert:
+        that:
+          - observability_loki_values.gateway.enabled is false
+          - observability_loki_values.chunksCache.enabled is false
+          - observability_loki_values.resultsCache.enabled is false
+          - observability_loki_values.lokiCanary.enabled is false
+          - observability_loki_values.ruler.enabled is false
+          - observability_loki_values.sidecar.rules.enabled is false
+          - observability_loki_values.minio.enabled is false
+          - observability_loki_values.test.enabled is false
+          - observability_loki_values.backend.replicas == 0
+          - observability_loki_values.read.replicas == 0
+          - observability_loki_values.write.replicas == 0
+          - observability_loki_values.ingester.replicas == 0
+          - observability_loki_values.querier.replicas == 0
+          - observability_loki_values.queryFrontend.replicas == 0
+          - observability_loki_values.queryScheduler.replicas == 0
+          - observability_loki_values.distributor.replicas == 0
+          - observability_loki_values.compactor.replicas == 0
+          - observability_loki_values.indexGateway.replicas == 0
+          - observability_loki_values.bloomPlanner.replicas == 0
+          - observability_loki_values.bloomBuilder.replicas == 0
+          - observability_loki_values.bloomGateway.replicas == 0
+
+    - name: Assert Loki monitoring exposes only the selected dashboards and critical alerts
+      ansible.builtin.assert:
+        that:
+          - observability_loki_values.monitoring.serviceMonitor.enabled is true
+          - observability_loki_values.monitoring.dashboards.enabled is true
+          - observability_loki_values.monitoring.dashboards.defaultDashboardsTimezone == "Europe/Warsaw"
+          - observability_loki_values.monitoring.dashboards['loki-logs'].enabled is true
+          - observability_loki_values.monitoring.dashboards['loki-retention'].enabled is true
+          - observability_loki_values.monitoring.dashboards['loki-operational'].enabled is false
+          - observability_loki_values.monitoring.alerts.enabled is true
+          - observability_loki_values.monitoring.alerts.disabled.LokiRequestLatency is true
+          - observability_loki_values.monitoring.alerts.disabled.LokiTooManyCompactorsRunning is true
+          - observability_loki_values.monitoring.alerts.overrides.LokiRequestErrors.severity == "critical"
+          - observability_loki_values.monitoring.alerts.overrides.LokiRequestPanics.severity == "critical"
+          - observability_loki_values.monitoring.alerts.overrides.LokiCompactorHasNotSuccessfullyRunCompaction.severity == "critical"
+          - observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[0].alert == "LokiDiscardingLogs"
+          - observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[0].for == "15m"
+          - observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[0].labels.severity == "critical"
+          - "'loki_discarded_samples_total' in observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[0].expr"
+          - observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[1].alert == "LokiStorageBackendAlmostFull"
+          - observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[1].for == "15m"
+          - observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[1].labels.severity == "critical"
+          - "'storage-loki-0' in observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[1].expr"
+          - "'< 0.10' in observability_loki_values.monitoring.additionalPrometheusRules['home-ops'].groups[0].rules[1].expr"
+
+    - name: Assert Alloy uses the pinned checkpointed StatefulSet
+      ansible.builtin.assert:
+        that:
+          - observability_alloy_app.chart.repo == "https://grafana.github.io/helm-charts"
+          - observability_alloy_app.chart.name == "alloy"
+          - observability_alloy_app.chart.version == "1.11.0"
+          - observability_alloy_app.sync.wave == "0"
+          - observability_alloy_values.crds.create is false
+          - observability_alloy_values.alloy.storagePath == "/var/lib/alloy"
+          - observability_alloy_values.alloy.enableReporting is false
+          - observability_alloy_values.alloy.clustering.enabled is false
+          - "'resources' not in observability_alloy_values.alloy"
+          - observability_alloy_values.configReloader.enabled is false
+          - observability_alloy_values.controller.type == "statefulset"
+          - observability_alloy_values.controller.replicas == 1
+          - observability_alloy_values.controller.enableStatefulSetAutoDeletePVC is false
+          - observability_alloy_values.controller.autoscaling.enabled is false
+          - observability_alloy_values.controller.autoscaling.horizontal.enabled is false
+          - observability_alloy_values.ingress.enabled is false
+          - observability_alloy_values.serviceMonitor.enabled is true
+          - observability_alloy_values.controller.volumeClaimTemplates[0].metadata.name == "storage"
+          - observability_alloy_values.controller.volumeClaimTemplates[0].spec.storageClassName == "nfs-fast"
+          - observability_alloy_values.controller.volumeClaimTemplates[0].spec.resources.requests.storage == "1Gi"
+          - observability_alloy_values.alloy.mounts.extra[0].name == "storage"
+          - observability_alloy_values.alloy.mounts.extra[0].mountPath == "/var/lib/alloy"
+
+    - name: Assert Alloy is non-root and has least-privilege Kubernetes API access
+      ansible.builtin.assert:
+        that:
+          - observability_alloy_values.global.podSecurityContext.runAsNonRoot is true
+          - observability_alloy_values.global.podSecurityContext.runAsUser == 473
+          - observability_alloy_values.global.podSecurityContext.runAsGroup == 473
+          - observability_alloy_values.global.podSecurityContext.fsGroup == 473
+          - observability_alloy_values.global.podSecurityContext.seccompProfile.type == "RuntimeDefault"
+          - observability_alloy_values.alloy.securityContext.runAsNonRoot is true
+          - observability_alloy_values.alloy.securityContext.runAsUser == 473
+          - observability_alloy_values.alloy.securityContext.runAsGroup == 473
+          - observability_alloy_values.alloy.securityContext.readOnlyRootFilesystem is true
+          - observability_alloy_values.alloy.securityContext.allowPrivilegeEscalation is false
+          - observability_alloy_values.alloy.securityContext.capabilities.drop == ["ALL"]
+          - observability_alloy_values.rbac.rules | length == 2
+          - observability_alloy_values.rbac.rules[0].resources == ["pods", "pods/log", "namespaces"]
+          - observability_alloy_values.rbac.rules[1].resources == ["events"]
+          - observability_alloy_values.rbac.clusterRules | length == 1
+          - observability_alloy_values.rbac.clusterRules[0].resources == ["nodes"]
+
+    - name: Assert Alloy pipelines satisfy the Loki metadata contract
+      ansible.builtin.assert:
+        that:
+          - '''loki.source.kubernetes "pod_logs"'' in observability_alloy_values.alloy.configMap.content'
+          - '''loki.source.kubernetes_events "cluster_events"'' in observability_alloy_values.alloy.configMap.content'
+          - (observability_alloy_values.alloy.configMap.content | regex_search('log_format\s*=\s*"logfmt"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('job_name\s*=\s*"kubernetes/events"')) is not none
+          - '''cluster = "homelab"'' in observability_alloy_values.alloy.configMap.content'
+          - (observability_alloy_values.alloy.configMap.content | regex_search('target_label\s*=\s*"namespace"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('target_label\s*=\s*"app"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('target_label\s*=\s*"container"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('pod\s*=\s*"pod"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('node\s*=\s*"node"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('container_image\s*=\s*"container_image"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('container_runtime\s*=\s*"container_runtime"')) is not none
+          - (observability_alloy_values.alloy.configMap.content | regex_search('stage\.label_drop\s*\{\s*values\s*=\s*\["job",\s*"instance"\]')) is not none
+          - "'http://loki.platform-system.svc.cluster.local:3100/loki/api/v1/push' in observability_alloy_values.alloy.configMap.content"
+
+    - name: Assert Grafana and Restic integrate with Loki and Alloy
+      ansible.builtin.assert:
+        that:
+          - observability_monitoring_values.grafana.additionalDataSources | selectattr("uid", "equalto", "loki") | length == 1
+          - (observability_monitoring_values.grafana.additionalDataSources | selectattr("uid", "equalto", "loki") | first).url == "http://loki.platform-system.svc.cluster.local:3100"
+          - (observability_monitoring_values.grafana.additionalDataSources | selectattr("uid", "equalto", "loki") | first).access == "proxy"
+          - (observability_monitoring_values.grafana.additionalDataSources | selectattr("uid", "equalto", "loki") | first).isDefault is false
+          - (observability_monitoring_values.grafana.additionalDataSources | selectattr("uid", "equalto", "loki") | first).editable is false
+          - (observability_monitoring_values.grafana.additionalDataSources | selectattr("uid", "equalto", "loki") | first).jsonData.maxLines == 1000
+          - "'/data/appdata/platform-system/storage-loki-0' not in observability_restic_values.controllers.backup.containers.app.args"
+          - "'/data/appdata/platform-system/storage-alloy-0' not in observability_restic_values.controllers.backup.containers.app.args"
+          - "'loki' not in observability_restic_defaults.restic_restore_excluded_apps"
+          - "'alloy' not in observability_restic_defaults.restic_restore_excluded_apps"

--- a/ansible/tests/restic-restore.yml
+++ b/ansible/tests/restic-restore.yml
@@ -46,6 +46,32 @@
               namespace: selfhosted
               name: restic-repo
       - metadata:
+          name: loki
+        spec:
+          destination:
+            namespace: platform-system
+        status:
+          resources:
+            - kind: PersistentVolumeClaim
+              namespace: platform-system
+              name: storage-loki-0
+            - kind: StatefulSet
+              namespace: platform-system
+              name: loki
+      - metadata:
+          name: alloy
+        spec:
+          destination:
+            namespace: platform-system
+        status:
+          resources:
+            - kind: PersistentVolumeClaim
+              namespace: platform-system
+              name: storage-alloy-0
+            - kind: StatefulSet
+              namespace: platform-system
+              name: alloy
+      - metadata:
           name: nfs-provisioner
         spec:
           destination:
@@ -76,6 +102,16 @@
           name: media
         spec:
           storageClassName: ""
+      - metadata:
+          namespace: platform-system
+          name: storage-loki-0
+        spec:
+          storageClassName: nfs-fast
+      - metadata:
+          namespace: platform-system
+          name: storage-alloy-0
+        spec:
+          storageClassName: nfs-fast
     restic_restore_workloads:
       - kind: Deployment
         metadata:
@@ -110,6 +146,30 @@
           template:
             spec:
               volumes: []
+      - kind: StatefulSet
+        metadata:
+          namespace: platform-system
+          name: loki
+        spec:
+          replicas: 1
+          template:
+            spec:
+              volumes: []
+          volumeClaimTemplates:
+            - metadata:
+                name: storage
+      - kind: StatefulSet
+        metadata:
+          namespace: platform-system
+          name: alloy
+        spec:
+          replicas: 1
+          template:
+            spec:
+              volumes: []
+          volumeClaimTemplates:
+            - metadata:
+                name: storage
 
   tasks:
     - name: Build single app restore plan
@@ -136,11 +196,13 @@
       vars:
         restic_restore_mode: all
 
-    - name: Assert restore-all includes platform appdata and excludes shared media and restic repo PVCs
+    - name: Assert restore-all includes logging and excludes shared storage
       ansible.builtin.assert:
         that:
-          - restic_restore_plan | length == 2
-          - restic_restore_plan | map(attribute="app") | sort | list == ["cert-data", "paperless"]
+          - restic_restore_plan | length == 4
+          - restic_restore_plan | map(attribute="app") | sort | list == ["alloy", "cert-data", "loki", "paperless"]
+          - (restic_restore_plan | selectattr("app", "equalto", "loki") | first).pvc_paths == ["/data/appdata/platform-system/storage-loki-0"]
+          - (restic_restore_plan | selectattr("app", "equalto", "alloy") | first).pvc_paths == ["/data/appdata/platform-system/storage-alloy-0"]
 
     - name: Read restore execution tasks
       ansible.builtin.slurp:

--- a/apps/platform-system/alloy/app.yaml
+++ b/apps/platform-system/alloy/app.yaml
@@ -1,0 +1,7 @@
+---
+chart:
+  repo: https://grafana.github.io/helm-charts
+  name: alloy
+  version: 1.11.0
+sync:
+  wave: "0"

--- a/apps/platform-system/alloy/values.yaml
+++ b/apps/platform-system/alloy/values.yaml
@@ -1,0 +1,192 @@
+---
+global:
+  podSecurityContext:
+    fsGroup: 473
+    fsGroupChangePolicy: OnRootMismatch
+    runAsGroup: 473
+    runAsNonRoot: true
+    runAsUser: 473
+    seccompProfile:
+      type: RuntimeDefault
+
+crds:
+  create: false
+
+alloy:
+  configMap:
+    content: |-
+      logging {
+        level  = "info"
+        format = "logfmt"
+      }
+
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      discovery.relabel "pod_logs" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          target_label  = "app"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label  = "container"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_node_name"]
+          target_label  = "node"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_image"]
+          target_label  = "container_image"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_id"]
+          regex         = "^([^:]+)://.*$"
+          replacement   = "$1"
+          target_label  = "container_runtime"
+        }
+      }
+
+      loki.source.kubernetes "pod_logs" {
+        targets    = discovery.relabel.pod_logs.output
+        forward_to = [loki.process.pod_logs.receiver]
+      }
+
+      loki.process "pod_logs" {
+        stage.static_labels {
+          values = {
+            cluster = "homelab",
+          }
+        }
+
+        stage.structured_metadata {
+          values = {
+            pod               = "pod",
+            node              = "node",
+            container_image   = "container_image",
+            container_runtime = "container_runtime",
+          }
+        }
+
+        stage.label_drop {
+          values = ["job", "instance"]
+        }
+
+        forward_to = [loki.write.local.receiver]
+      }
+
+      loki.source.kubernetes_events "cluster_events" {
+        job_name   = "kubernetes/events"
+        log_format = "logfmt"
+        forward_to = [loki.process.cluster_events.receiver]
+      }
+
+      loki.process "cluster_events" {
+        stage.static_labels {
+          values = {
+            cluster = "homelab",
+          }
+        }
+
+        forward_to = [loki.write.local.receiver]
+      }
+
+      loki.write "local" {
+        endpoint {
+          url = "http://loki.platform-system.svc.cluster.local:3100/loki/api/v1/push"
+        }
+      }
+  clustering:
+    enabled: false
+  enableReporting: false
+  mounts:
+    extra:
+      - name: storage
+        mountPath: /var/lib/alloy
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsGroup: 473
+    runAsNonRoot: true
+    runAsUser: 473
+  storagePath: /var/lib/alloy
+
+configReloader:
+  enabled: false
+
+controller:
+  type: statefulset
+  replicas: 1
+  enableStatefulSetAutoDeletePVC: false
+  autoscaling:
+    enabled: false
+    horizontal:
+      enabled: false
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: nfs-fast
+        resources:
+          requests:
+            storage: 1Gi
+
+rbac:
+  create: true
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - pods
+        - pods/log
+        - namespaces
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - ""
+      resources:
+        - events
+      verbs:
+        - get
+        - list
+        - watch
+  clusterRules:
+    - apiGroups:
+        - ""
+      resources:
+        - nodes
+      verbs:
+        - get
+        - list
+        - watch
+
+serviceMonitor:
+  enabled: true
+
+ingress:
+  enabled: false

--- a/apps/platform-system/kube-prometheus-stack/values.yaml
+++ b/apps/platform-system/kube-prometheus-stack/values.yaml
@@ -35,6 +35,16 @@ alertmanager:
     useExistingSecret: true
 
 grafana:
+  additionalDataSources:
+    - name: Loki
+      uid: loki
+      type: loki
+      access: proxy
+      url: http://loki.platform-system.svc.cluster.local:3100
+      isDefault: false
+      editable: false
+      jsonData:
+        maxLines: 1000
   admin:
     existingSecret: grafana-credentials
     userKey: admin-user

--- a/apps/platform-system/loki/app.yaml
+++ b/apps/platform-system/loki/app.yaml
@@ -1,0 +1,7 @@
+---
+chart:
+  repo: https://grafana-community.github.io/helm-charts
+  name: loki
+  version: 18.5.4
+sync:
+  wave: "0"

--- a/apps/platform-system/loki/values.yaml
+++ b/apps/platform-system/loki/values.yaml
@@ -1,0 +1,174 @@
+---
+deploymentMode: Monolithic
+
+defaults:
+  automountServiceAccountToken: false
+
+serviceAccount:
+  automountServiceAccountToken: false
+
+loki:
+  auth_enabled: false
+  analytics:
+    reporting_enabled: false
+  commonConfig:
+    path_prefix: /var/loki
+    replication_factor: 1
+  compactor:
+    delete_request_store: filesystem
+    retention_enabled: true
+  limits_config:
+    allow_structured_metadata: true
+    discover_log_levels: true
+    reject_old_samples: true
+    reject_old_samples_max_age: 168h
+    retention_period: 720h
+    volume_enabled: true
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  storage:
+    type: filesystem
+
+singleBinary:
+  replicas: 1
+  affinity: {}
+  podDisruptionBudget:
+    enabled: false
+  persistence:
+    enabled: true
+    enableStatefulSetAutoDeletePVC: true
+    accessModes:
+      - ReadWriteOnce
+    size: 30Gi
+    storageClass: nfs-fast
+    whenDeleted: Retain
+    whenScaled: Retain
+
+gateway:
+  enabled: false
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+lokiCanary:
+  enabled: false
+ruler:
+  enabled: false
+sidecar:
+  rules:
+    enabled: false
+minio:
+  enabled: false
+test:
+  enabled: false
+
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+ingester:
+  replicas: 0
+querier:
+  replicas: 0
+queryFrontend:
+  replicas: 0
+queryScheduler:
+  replicas: 0
+distributor:
+  replicas: 0
+compactor:
+  replicas: 0
+indexGateway:
+  replicas: 0
+bloomPlanner:
+  replicas: 0
+bloomBuilder:
+  replicas: 0
+bloomGateway:
+  replicas: 0
+
+monitoring:
+  dashboards:
+    enabled: true
+    defaultDashboardsTimezone: Europe/Warsaw
+    loki-bloom-build:
+      enabled: false
+    loki-bloom-gateway:
+      enabled: false
+    loki-chunks:
+      enabled: false
+    loki-deletion:
+      enabled: false
+    loki-logs:
+      enabled: true
+    loki-mixin-recording-rules:
+      enabled: false
+    loki-operational:
+      enabled: false
+    loki-reads:
+      enabled: false
+    loki-reads-resources:
+      enabled: false
+    loki-retention:
+      enabled: true
+    loki-thanos-object-storage:
+      enabled: false
+    loki-writes:
+      enabled: false
+    loki-writes-resources:
+      enabled: false
+  alerts:
+    enabled: true
+    disabled:
+      LokiRequestLatency: true
+      LokiTooManyCompactorsRunning: true
+    overrides:
+      LokiRequestErrors:
+        severity: critical
+      LokiRequestPanics:
+        severity: critical
+      LokiCompactorHasNotSuccessfullyRunCompaction:
+        severity: critical
+  additionalPrometheusRules:
+    home-ops:
+      groups:
+        - name: home-ops.loki
+          rules:
+            - alert: LokiDiscardingLogs
+              expr: sum by (reason) (rate(loki_discarded_samples_total[5m])) > 0
+              for: 15m
+              labels:
+                severity: critical
+              annotations:
+                summary: "Loki is discarding log samples"
+                description: "Loki has continuously discarded log samples for reason {{ $labels.reason }} for 15 minutes."
+            - alert: LokiStorageBackendAlmostFull
+              expr: |
+                (
+                  kubelet_volume_stats_available_bytes{
+                    namespace="platform-system",
+                    persistentvolumeclaim="storage-loki-0"
+                  }
+                  /
+                  kubelet_volume_stats_capacity_bytes{
+                    namespace="platform-system",
+                    persistentvolumeclaim="storage-loki-0"
+                  }
+                ) < 0.10
+              for: 15m
+              labels:
+                severity: critical
+              annotations:
+                summary: "Loki NFS storage is almost full"
+                description: "The NFS share backing storage-loki-0 has less than 10% free space for 15 minutes."
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
## What changed

- Add Loki chart `18.5.4` / Loki `3.7.4` as a single monolithic StatefulSet with TSDB v13, filesystem storage, 30-day retention, and a retained 30Gi `nfs-fast` claim.
- Add Alloy chart `1.11.0` / Alloy `1.18.0` as a hardened, checkpointed StatefulSet collecting pod stdout/stderr and Kubernetes Events through the Kubernetes API.
- Provision the internal Grafana Loki datasource, selected Loki dashboards, ServiceMonitors, and critical Loki/storage alerts.
- Exclude Loki data and Alloy checkpoints from Restic backup and restore-all planning.
- Add observability and restore contracts plus README/AGENTS guidance.

## Why

This adds lightweight, internal-only log aggregation suited to the single-node homelab without deploying Loki's distributed components or privileged node log collectors.

## Impact

- No CPU or memory requests/limits are configured.
- Loki and Alloy have no HTTPRoutes; access remains through Grafana.
- Reachable LAN/Tailscale users retain anonymous Grafana Viewer access and can query collected logs.
- The NFS PVC requests describe allocation intent; the free-space alert measures the shared `nfs-fast` backing filesystem.

## Validation

- `task fmt`
- `task lint`
- `git diff --check`
- Focused observability and Restic Ansible contracts
- Helm dry-renders for Loki, Alloy, and kube-prometheus-stack
- Loki `3.7.4` generated-config verification
- Alloy `1.18.0` configuration validation
- Independent review of label cardinality, retention, RBAC, security, and NFS alert semantics

## Post-merge rollout

Sync Loki, Alloy, and kube-prometheus-stack; verify PVCs, pods, Prometheus targets, datasource health, pod/event LogQL queries, and alert availability. Observe runtime use and NFS growth for 24 hours before considering resource reservations.