### PR TITLE
fix karakeep meilisearch startup

### DIFF
--- a/apps/selfhosted/karakeep/values.yaml
+++ b/apps/selfhosted/karakeep/values.yaml
@@ -133,7 +133,7 @@ controllers:
           tag: v1.51.0
         args:
           - /bin/meilisearch
-          - --experimental-dumpless-upgrade
+          - --upgrade-db
         env:
           MEILI_NO_ANALYTICS: "true"
           MEILI_MASTER_KEY:


### PR DESCRIPTION
## What changed

- replace Meilisearch's removed `--experimental-dumpless-upgrade` flag with its v1.51 replacement, `--upgrade-db`

## Why

Meilisearch v1.51.0 renamed the dumpless-upgrade flag. The obsolete argument causes `karakeep-meilisearch` to exit with code 2 and remain in `CrashLoopBackOff`, leaving Karakeep without a ready search endpoint.

## Validation

- `task fmt`
- `task lint`
- live failure reproduced from the Meilisearch pod logs