### PR TITLE
fix(observability): complete Victoria cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ controllers:
   dedicated node-local `/var/lib/vl-collector` queue. Kubernetes Events are not
   collected.
 - Log stream fields are `cluster`, `kubernetes.pod_namespace`,
-  `kubernetes.pod_labels.app_kubernetes_io_name`, and
+  `kubernetes.pod_labels.app.kubernetes.io/name`, and
   `kubernetes.container_name`. Pod, node, image, runtime, and other Kubernetes
   metadata remain ordinary searchable fields.
 - Grafana provisions VictoriaLogs as a non-editable internal datasource with UID

--- a/README.md
+++ b/README.md
@@ -114,14 +114,18 @@ indexers. Compatibility-only resources and controllers are prohibited, while
 VMAlert and VMAlertmanager CRDs remain absent.
 
 After a merged migration has been verified in the cluster, the retained legacy
-observability claims can be deleted with the guarded workflow:
+observability claims, unused Prometheus Operator CRDs, and retired kubelet scrape
+service can be deleted with the guarded workflow:
 
 ```bash
 task observability:cleanup-old-pvcs confirm_cleanup=true
 ```
 
-The workflow refuses to run unless the replacement claims exist and the retired
-StatefulSets have already been pruned.
+The workflow refuses to run unless the replacement claims exist, the retired
+StatefulSets have been pruned, and every legacy Prometheus custom resource type is
+empty. VLAgent streams use VictoriaLogs' native `cluster`,
+`kubernetes.pod_namespace`, `kubernetes.pod_labels.app.kubernetes.io/name`, and
+`kubernetes.container_name` field names.
 
 ## Repository Layout
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -296,7 +296,7 @@ tasks:
       - '"{{.ANSIBLE_PLAYBOOK}}" ansible/playbooks/restic-restore.yml -e "restic_restore_mode=all" -e "restic_restore_snapshot={{.snapshot}}" -e "restic_restore_confirm={{.confirm_restore}}"'
 
   observability:cleanup-old-pvcs:
-    desc: Delete retired Prometheus, Alertmanager, Grafana, Loki, and Alloy PVCs after cutover
+    desc: Delete retired observability PVCs, Prometheus CRDs, and kubelet scrape service
     interactive: true
     dir: "{{.TASKFILE_DIR}}"
     deps:

--- a/ansible/playbooks/observability-cleanup-old-pvcs.yml
+++ b/ansible/playbooks/observability-cleanup-old-pvcs.yml
@@ -1,5 +1,5 @@
 ---
-- name: Delete retired observability PVCs after the Victoria cutover
+- name: Delete retired observability resources after the Victoria cutover
   hosts: localhost
   gather_facts: false
   vars:
@@ -21,14 +21,45 @@
       - storage-alloy-0
       - storage-kube-prometheus-stack-grafana-0
       - storage-loki-0
+    observability_cleanup_old_custom_resources:
+      - api_version: monitoring.coreos.com/v1alpha1
+        kind: AlertmanagerConfig
+        crd: alertmanagerconfigs.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: Alertmanager
+        crd: alertmanagers.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: PodMonitor
+        crd: podmonitors.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: Probe
+        crd: probes.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1alpha1
+        kind: PrometheusAgent
+        crd: prometheusagents.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: Prometheus
+        crd: prometheuses.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        crd: prometheusrules.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1alpha1
+        kind: ScrapeConfig
+        crd: scrapeconfigs.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        crd: servicemonitors.monitoring.coreos.com
+      - api_version: monitoring.coreos.com/v1
+        kind: ThanosRuler
+        crd: thanosrulers.monitoring.coreos.com
 
   tasks:
-    - name: Require explicit legacy observability PVC cleanup confirmation
+    - name: Require explicit legacy observability cleanup confirmation
       ansible.builtin.assert:
         that:
           - observability_cleanup_confirm | bool
         fail_msg: >-
-          Refusing to delete legacy observability PVCs. Re-run with
+          Refusing to delete legacy observability resources. Re-run with
           observability_cleanup_confirm=true only after the Victoria cutover has been verified.
 
     - name: Read StatefulSets remaining in the observability namespace
@@ -68,6 +99,68 @@
       loop: "{{ observability_cleanup_replacement_claims.results }}"
       loop_control:
         label: "{{ item.item }}"
+
+    - name: Read retired Prometheus Operator CRDs
+      kubernetes.core.k8s_info:
+        context: "{{ kube_context }}"
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: "{{ item.crd }}"
+      loop: "{{ observability_cleanup_old_custom_resources }}"
+      loop_control:
+        label: "{{ item.crd }}"
+      register: observability_cleanup_old_crds
+
+    - name: Reset present Prometheus custom resource types
+      ansible.builtin.set_fact:
+        observability_cleanup_present_custom_resources: []
+
+    - name: Select installed Prometheus custom resource types
+      ansible.builtin.set_fact:
+        observability_cleanup_present_custom_resources: "{{ observability_cleanup_present_custom_resources + [item.item] }}"
+      when: item.resources | length == 1
+      loop: "{{ observability_cleanup_old_crds.results }}"
+      loop_control:
+        label: "{{ item.item.kind }}"
+
+    - name: Read legacy Prometheus custom resources
+      kubernetes.core.k8s_info:
+        context: "{{ kube_context }}"
+        api_version: "{{ item.api_version }}"
+        kind: "{{ item.kind }}"
+      loop: "{{ observability_cleanup_present_custom_resources }}"
+      loop_control:
+        label: "{{ item.kind }}"
+      register: observability_cleanup_old_resources
+
+    - name: Assert legacy Prometheus custom resources are absent
+      ansible.builtin.assert:
+        that:
+          - item.resources | length == 0
+        fail_msg: "Refusing to delete {{ item.item.crd }} while {{ item.item.kind }} resources still exist."
+      loop: "{{ observability_cleanup_old_resources.results }}"
+      loop_control:
+        label: "{{ item.item.kind }}"
+
+    - name: Delete retired Prometheus kubelet service
+      kubernetes.core.k8s:
+        context: "{{ kube_context }}"
+        state: absent
+        api_version: v1
+        kind: Service
+        name: kube-prometheus-stack-kubelet
+        namespace: kube-system
+
+    - name: Delete retired Prometheus Operator CRDs
+      kubernetes.core.k8s:
+        context: "{{ kube_context }}"
+        state: absent
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: "{{ item.crd }}"
+      loop: "{{ observability_cleanup_old_custom_resources }}"
+      loop_control:
+        label: "{{ item.crd }}"
 
     - name: Delete exact retired observability claims
       kubernetes.core.k8s:

--- a/ansible/tests/observability-logging.yml
+++ b/ansible/tests/observability-logging.yml
@@ -110,6 +110,17 @@
       - victoriametrics-vmagent
       - victoriatraces-cluster
       - victoriatraces-single-node
+    observability_legacy_prometheus_crds:
+      - alertmanagerconfigs.monitoring.coreos.com
+      - alertmanagers.monitoring.coreos.com
+      - podmonitors.monitoring.coreos.com
+      - probes.monitoring.coreos.com
+      - prometheusagents.monitoring.coreos.com
+      - prometheuses.monitoring.coreos.com
+      - prometheusrules.monitoring.coreos.com
+      - scrapeconfigs.monitoring.coreos.com
+      - servicemonitors.monitoring.coreos.com
+      - thanosrulers.monitoring.coreos.com
 
   tasks:
     - name: Find the selectively vendored VictoriaMetrics CRDs
@@ -214,6 +225,7 @@
           - observability_metrics_values.grafana['grafana.ini'].recording_rules is not defined
           - observability_metrics_values.grafana.envFromSecret == "grafana-alerting-credentials"
           - observability_metrics_values.grafana.plugins == ["victoriametrics-logs-datasource@0.30.1"]
+          - observability_metrics_values.grafana['grafana.ini'].plugins.preinstall_disabled is false
           - observability_metrics_values.grafana.resources.limits is not defined
           - observability_metrics_values.grafana.extraConfigmapMounts[0].configMap == "grafana-alerting-provisioning"
           - observability_metrics_values.grafana.extraConfigmapMounts[0].mountPath == "/etc/grafana/provisioning/alerting"
@@ -238,6 +250,7 @@
       ansible.builtin.assert:
         that:
           - observability_grafana_rules.apiVersion == 1
+          - observability_grafana_rules.groups | map(attribute='folder') | unique == ['Home Ops Alerts']
           - observability_all_grafana_rules | length == 20
           - observability_all_grafana_rules | selectattr('record', 'defined') | length == 0
           - observability_all_grafana_rules | map(attribute='noDataState') | unique == ['OK']
@@ -326,7 +339,7 @@
           - observability_collector_app.sync.wave == "0"
           - observability_collector_values.remoteWrite[0].url == "http://victoria-logs-single-server.platform-system.svc.cluster.local:9428"
           - observability_collector_values.collector.extraFields == '{"cluster":"homelab"}'
-          - observability_collector_values.collector.streamFields == ["cluster", "kubernetes.pod_namespace", "kubernetes.pod_labels.app_kubernetes_io_name", "kubernetes.container_name"]
+          - observability_collector_values.collector.streamFields == ["cluster", "kubernetes.pod_namespace", "kubernetes.pod_labels.app.kubernetes.io/name", "kubernetes.container_name"]
           - observability_collector_values.collector.includePodLabels is true
           - observability_collector_values.collector.includePodAnnotations is false
           - observability_collector_values.collector.includeNodeLabels is false
@@ -417,3 +430,13 @@
           - "'storage-alloy-0' in (observability_cleanup_workflow.content | b64decode)"
           - "'storage-kube-prometheus-stack-grafana-0' in (observability_cleanup_workflow.content | b64decode)"
           - "'storage-loki-0' in (observability_cleanup_workflow.content | b64decode)"
+          - "'kind: CustomResourceDefinition' in (observability_cleanup_workflow.content | b64decode)"
+          - "'kind: Service' in (observability_cleanup_workflow.content | b64decode)"
+          - "'kube-prometheus-stack-kubelet' in (observability_cleanup_workflow.content | b64decode)"
+          - "'observability_cleanup_old_custom_resources' in (observability_cleanup_workflow.content | b64decode)"
+
+    - name: Assert cleanup names every legacy Prometheus Operator CRD
+      ansible.builtin.assert:
+        that:
+          - item in (observability_cleanup_workflow.content | b64decode)
+      loop: "{{ observability_legacy_prometheus_crds }}"

--- a/apps/platform-system/victoria-logs-collector/values.yaml
+++ b/apps/platform-system/victoria-logs-collector/values.yaml
@@ -8,7 +8,7 @@ collector:
   streamFields:
     - cluster
     - kubernetes.pod_namespace
-    - kubernetes.pod_labels.app_kubernetes_io_name
+    - kubernetes.pod_labels.app.kubernetes.io/name
     - kubernetes.container_name
   includePodLabels: true
   includePodAnnotations: false

--- a/apps/platform-system/victoria-metrics-k8s-stack/manifests/victoria-metrics-k8s-stack-grafana-alerting.configmap.yaml
+++ b/apps/platform-system/victoria-metrics-k8s-stack/manifests/victoria-metrics-k8s-stack-grafana-alerting.configmap.yaml
@@ -12,7 +12,7 @@ data:
     groups:
     - orgId: 1
       name: home-ops-actionable
-      folder: Home Ops
+      folder: Home Ops Alerts
       interval: 1m
       rules:
       - uid: alt-9f7900c1e4c053b2b46b7ea3

--- a/apps/platform-system/victoria-metrics-k8s-stack/values.yaml
+++ b/apps/platform-system/victoria-metrics-k8s-stack/values.yaml
@@ -129,7 +129,7 @@ grafana:
       org_role: Viewer
     plugins:
       preinstall_auto_update: false
-      preinstall_disabled: true
+      preinstall_disabled: false
     server:
       root_url: https://grafana.edgard.org
   persistence:


### PR DESCRIPTION
## Summary
- enable the pinned VictoriaLogs Grafana plugin and restore file-provisioned alerts in a dedicated folder
- correct the VLAgent native app stream field
- guard and automate cleanup of the exact legacy Prometheus CRDs, kubelet service, and observability PVCs

## Validation
- `task fmt:check`
- `task lint:ansible`
- `task lint:kubernetes`
- `task lint`
- live cleanup playbook check-mode audit
- independent review: no findings