### PR TITLE
fix(dns): restore Gateway LAN records

### DIFF
--- a/apps/platform-system/istio/manifests/istio-gateway.gateway.yaml
+++ b/apps/platform-system/istio/manifests/istio-gateway.gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gateway
   namespace: platform-system
   annotations:
-    external-dns.alpha.kubernetes.io/target: 192.168.1.241
+    external-dns.kubernetes.io/target: 192.168.1.241
     networking.istio.io/service-type: ClusterIP
 spec:
   gatewayClassName: istio

--- a/policy/kubernetes/routes.rego
+++ b/policy/kubernetes/routes.rego
@@ -21,3 +21,19 @@ has_expected_gateway_parent_ref if {
   object.get(ref, "namespace", "") == "platform-system"
   object.get(ref, "sectionName", "") == "https"
 }
+
+deny contains msg if {
+  annotations := object.get(input.metadata, "annotations", {})
+  some annotation in object.keys(annotations)
+  startswith(annotation, "external-dns.alpha.kubernetes.io/")
+  msg := sprintf("%s/%s uses retired ExternalDNS annotation %s", [input.kind, input.metadata.name, annotation])
+}
+
+deny contains msg if {
+  input.kind == "Gateway"
+  input.metadata.name == "gateway"
+  object.get(input.metadata, "namespace", "") == "platform-system"
+  annotations := object.get(input.metadata, "annotations", {})
+  object.get(annotations, "external-dns.kubernetes.io/target", "") != "192.168.1.241"
+  msg := "Gateway/gateway must set external-dns.kubernetes.io/target to 192.168.1.241"
+}

--- a/policy/kubernetes/routes_test.rego
+++ b/policy/kubernetes/routes_test.rego
@@ -30,3 +30,52 @@ test_httproute_allows_unannotated_routes if {
   results := deny with input as route
   count(results) == 0
 }
+
+test_legacy_external_dns_annotations_are_rejected_on_any_resource if {
+  service := {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "name": "demo",
+      "namespace": "platform-system",
+      "annotations": {
+        "external-dns.alpha.kubernetes.io/target": "192.168.1.241",
+      },
+    },
+  }
+
+  "Service/demo uses retired ExternalDNS annotation external-dns.alpha.kubernetes.io/target" in deny with input as service
+}
+
+test_shared_gateway_requires_modern_lan_target if {
+  gateway := {
+    "apiVersion": "gateway.networking.k8s.io/v1",
+    "kind": "Gateway",
+    "metadata": {
+      "name": "gateway",
+      "namespace": "platform-system",
+      "annotations": {
+        "external-dns.alpha.kubernetes.io/target": "192.168.1.241",
+      },
+    },
+  }
+
+  "Gateway/gateway must set external-dns.kubernetes.io/target to 192.168.1.241" in deny with input as gateway
+}
+
+test_shared_gateway_allows_modern_lan_target if {
+  gateway := {
+    "apiVersion": "gateway.networking.k8s.io/v1",
+    "kind": "Gateway",
+    "metadata": {
+      "name": "gateway",
+      "namespace": "platform-system",
+      "annotations": {
+        "external-dns.kubernetes.io/target": "192.168.1.241",
+      },
+    },
+  }
+
+  results := deny with input as gateway
+  count(results) == 0
+}

--- a/scripts/validate-kubernetes.sh
+++ b/scripts/validate-kubernetes.sh
@@ -527,6 +527,14 @@ validate_policies() {
   conftest test --no-color --policy "$policy_dir" "${paths[@]}"
 }
 
+validate_policy_tests() {
+  local policy_dir
+
+  for policy_dir in metadata source kubernetes; do
+    conftest verify --no-color --policy "${repo_root}/policy/${policy_dir}"
+  done
+}
+
 validate_manifests() {
   local paths=()
   local kubernetes_version
@@ -643,6 +651,9 @@ main() {
 
   log_step "Metadata policy"
   validate_metadata
+
+  log_step "Policy unit tests"
+  validate_policy_tests
 
   log_step "Raw manifest policy"
   validate_policies


### PR DESCRIPTION
## Summary

- migrate the shared Gateway target annotation to the ExternalDNS v0.22 prefix
- reject retired `external-dns.alpha.kubernetes.io/*` annotations on any resource
- pin the shared Gateway LAN target to `192.168.1.241`
- run all Rego unit suites in the Kubernetes quality gate

## Root cause

ExternalDNS v0.22 ignored the retired alpha target annotation, so routed hostnames were published as in-cluster CNAMEs instead of LAN A records.

## Validation

- `task fmt:check`
- `task lint:kubernetes`
- `task lint`
- independent review: no remaining critical or important findings
- repository scan: no retired ExternalDNS annotations remain under apps, Ansible, or scripts