### PR TITLE
feat(observability): redesign Home Ops dashboard

### DIFF
--- a/ansible/tests/observability.yml
+++ b/ansible/tests/observability.yml
@@ -110,6 +110,107 @@
       - victoriametrics-vmagent
       - victoriatraces-cluster
       - victoriatraces-single-node
+    observability_home_overview_rows:
+      - Current status
+      - Workloads and safety
+      - Capacity
+      - Service health
+    observability_home_overview_panels:
+      - Active alerts
+      - External reachability
+      - Kubernetes node
+      - Backup freshness
+      - Argo CD applications
+      - Certificate expiry
+      - Pod restarts
+      - OOM kills
+      - CPU used
+      - Memory used
+      - Node filesystem free
+      - PVC health
+      - CPU / memory trend
+      - PVC headroom
+      - Largest pods
+      - HTTP / DNS / ICMP health
+      - Slowest HTTP routes
+      - Core scrape services
+      - Observability components
+    observability_home_overview_links:
+      - title: Node Exporter Full
+        type: link
+        url: /d/rYdddlPWk/node-exporter-full
+      - title: VictoriaMetrics Single
+        type: link
+        url: /d/wNf0q_kZk/victoriametrics-single-node
+      - title: VictoriaLogs Single
+        type: link
+        url: /d/OqPIZTX4z/victorialogs-single-node
+      - title: Pod Logs Explorer
+        type: link
+        url: /d/home-ops-pod-logs/kubernetes-pod-logs
+    observability_home_overview_layout:
+      - Current status
+      - Active alerts
+      - External reachability
+      - Kubernetes node
+      - Backup freshness
+      - Workloads and safety
+      - Argo CD applications
+      - Certificate expiry
+      - Pod restarts
+      - OOM kills
+      - Capacity
+      - CPU used
+      - Memory used
+      - Node filesystem free
+      - PVC health
+      - CPU / memory trend
+      - PVC headroom
+      - Largest pods
+      - Service health
+      - HTTP / DNS / ICMP health
+      - Slowest HTTP routes
+      - Core scrape services
+      - Observability components
+    observability_home_overview_compact_cards:
+      - Active alerts
+      - External reachability
+      - Kubernetes node
+      - Backup freshness
+      - Argo CD applications
+      - Certificate expiry
+      - Pod restarts
+      - OOM kills
+      - CPU used
+      - Memory used
+      - Node filesystem free
+      - PVC health
+    observability_home_overview_compact_grid_positions:
+      - {x: 0, y: 1, w: 6, h: 3}
+      - {x: 6, y: 1, w: 6, h: 3}
+      - {x: 12, y: 1, w: 6, h: 3}
+      - {x: 18, y: 1, w: 6, h: 3}
+      - {x: 0, y: 5, w: 6, h: 3}
+      - {x: 6, y: 5, w: 6, h: 3}
+      - {x: 12, y: 5, w: 6, h: 3}
+      - {x: 18, y: 5, w: 6, h: 3}
+      - {x: 0, y: 9, w: 6, h: 3}
+      - {x: 6, y: 9, w: 6, h: 3}
+      - {x: 12, y: 9, w: 6, h: 3}
+      - {x: 18, y: 9, w: 6, h: 3}
+    observability_home_overview_compact_expressions:
+      - 'sum(grafana_alerting_active_alerts{job="victoria-metrics-k8s-stack-grafana"}) or vector(-1)'
+      - "(count(probe_success == 0) or (count(probe_success) * 0)) or vector(-1)"
+      - 'min(kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}) or vector(-1)'
+      - '(((time() - max(kube_cronjob_status_last_successful_time{namespace="selfhosted",cronjob="restic-backup"})) or (time() - max(kube_cronjob_created{namespace="selfhosted",cronjob="restic-backup"}))) / 3600) or vector(-1)'
+      - '(sum((argocd_app_info{health_status!~"Healthy|Progressing"} == 1) or (argocd_app_info{sync_status!="Synced"} == 1)) or (count(argocd_app_info) * 0)) or vector(-1)'
+      - "min((certmanager_certificate_expiration_timestamp_seconds - time()) / 86400) or vector(-1)"
+      - "(sum(increase(kube_pod_container_status_restarts_total[1h])) or (count(kube_pod_container_status_restarts_total) * 0)) or vector(-1)"
+      - '(sum(increase(container_oom_events_total{job="kubelet",metrics_path="/metrics/cadvisor",container!="",pod!=""}[24h])) or (count(container_oom_events_total{job="kubelet",metrics_path="/metrics/cadvisor",container!="",pod!=""}) * 0)) or vector(-1)'
+      - '100 * (1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[5m]))) or vector(-1)'
+      - '100 * (1 - avg(node_memory_MemAvailable_bytes{job="node-exporter"} / node_memory_MemTotal_bytes{job="node-exporter"})) or vector(-1)'
+      - 'min(100 * node_filesystem_avail_bytes{job="node-exporter",fstype!~"tmpfs|fuse.*|overlay|squashfs"} / node_filesystem_size_bytes{job="node-exporter",fstype!~"tmpfs|fuse.*|overlay|squashfs"}) or vector(-1)'
+      - '(sum(kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} == 1) or (count(kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"}) * 0)) or vector(-1)'
   tasks:
     - name: Find the selectively vendored VictoriaMetrics CRDs
       ansible.builtin.find:
@@ -140,6 +241,20 @@
         - ansible/roles/restic/defaults/main.yml
       register: observability_files
 
+    - name: Find Grafana dashboard ConfigMaps
+      ansible.builtin.find:
+        paths: "{{ observability_repo_root }}/apps"
+        patterns: "*.configmap.yaml"
+        recurse: true
+        file_type: file
+      register: observability_configmap_files
+
+    - name: Read Grafana dashboard ConfigMaps
+      ansible.builtin.slurp:
+        src: "{{ item.path }}"
+      loop: "{{ observability_configmap_files.files }}"
+      register: observability_configmap_contents
+
     - name: Parse Victoria observability configuration
       ansible.builtin.set_fact:
         observability_metrics_app: "{{ observability_files.results[0].content | b64decode | from_yaml }}"
@@ -153,6 +268,10 @@
         observability_home_dashboard: "{{ observability_files.results[8].content | b64decode | from_yaml }}"
         observability_restic_values: "{{ observability_files.results[9].content | b64decode | from_yaml }}"
         observability_restic_defaults: "{{ observability_files.results[10].content | b64decode | from_yaml }}"
+
+    - name: Select Grafana dashboard ConfigMaps
+      ansible.builtin.set_fact:
+        observability_custom_dashboard_configmaps: "{{ observability_configmap_contents.results | map(attribute='content') | map('b64decode') | map('from_yaml') | selectattr('metadata.labels.grafana_dashboard', 'defined') | selectattr('metadata.labels.grafana_dashboard', 'equalto', '1') | list }}"
 
     - name: Parse Grafana alerting provisioning files
       ansible.builtin.set_fact:
@@ -357,26 +476,165 @@
           - '''cluster:="homelab"'' in (observability_logs_dashboard.data[''pod-logs.json''] | from_json).panels[0].targets[0].expr'
           - "'kubernetes.pod_namespace' in (observability_logs_dashboard.data['pod-logs.json'] | from_json).panels[0].targets[0].expr"
 
+    - name: Parse the Home Ops overview dashboard
+      ansible.builtin.set_fact:
+        observability_home_overview: "{{ observability_home_dashboard.data['home-ops-overview.json'] | from_json }}"
+
+    - name: Select Home Ops overview dashboard panels
+      ansible.builtin.set_fact:
+        observability_home_overview_rows_actual: "{{ observability_home_overview.panels | selectattr('type', 'equalto', 'row') | list }}"
+        observability_home_overview_panels_actual: "{{ observability_home_overview.panels | rejectattr('type', 'equalto', 'row') | list }}"
+
     - name: Assert the exact lean dashboard inventory
       ansible.builtin.assert:
         that:
           - observability_enabled_dashboards | difference(observability_metrics_values.defaultDashboards.dashboards.keys() | list) | length == 0
           - observability_disabled_dashboards | difference(observability_metrics_values.defaultDashboards.dashboards.keys() | list) | length == 0
+          - observability_metrics_values.defaultDashboards.dashboards | dict2items | selectattr('value.enabled') | list | length == 3
+          - observability_custom_dashboard_configmaps | length == 2
+          - observability_custom_dashboard_configmaps | selectattr('metadata.name', 'equalto', 'victoria-metrics-k8s-stack-home-ops-overview') | selectattr('metadata.namespace', 'equalto', 'platform-system') | list | length == 1
+          - observability_custom_dashboard_configmaps | selectattr('metadata.name', 'equalto', 'victoria-logs-pod-explorer') | selectattr('metadata.namespace', 'equalto', 'platform-system') | list | length == 1
           - observability_metrics_values.defaultDashboards.dashboards | dict2items | selectattr('key', 'in', observability_enabled_dashboards) | map(attribute='value.enabled') | unique == [true]
           - observability_metrics_values.defaultDashboards.dashboards | dict2items | selectattr('key', 'in', observability_disabled_dashboards) | map(attribute='value.enabled') | unique == [false]
           - observability_metrics_values.defaultDashboards.sources | dict2items | selectattr('key', 'in', observability_enabled_dashboard_sources) | map(attribute='value.enabled') | unique == [true]
           - observability_metrics_values.defaultDashboards.sources | dict2items | selectattr('key', 'in', observability_disabled_dashboard_sources) | map(attribute='value.enabled') | unique == [false]
           - observability_home_dashboard.metadata.labels.grafana_dashboard == "1"
-          - (observability_home_dashboard.data['home-ops-overview.json'] | from_json).uid == "home-ops-overview"
-          - (observability_home_dashboard.data['home-ops-overview.json'] | from_json).title == "Home Ops Overview"
-          - "'probe_success' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'probe_duration_seconds' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'node_memory_MemAvailable_bytes' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'container_memory_working_set_bytes' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'container_oom_events_total' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'kube_cronjob_status_last_successful_time' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'kube_node_status_condition' in observability_home_dashboard.data['home-ops-overview.json']"
-          - "'argocd_app_info' in observability_home_dashboard.data['home-ops-overview.json']"
+          - observability_home_overview.uid == "home-ops-overview"
+          - observability_home_overview.title == "Home Ops Overview"
+          - observability_home_overview.refresh == "30s"
+          - 'observability_home_overview.time == {"from": "now-6h", "to": "now"}'
+          - observability_home_overview_rows_actual | map(attribute='title') | list == observability_home_overview_rows
+          - observability_home_overview_panels_actual | map(attribute='title') | list == observability_home_overview_panels
+          - observability_home_overview.panels | map(attribute='title') | list == observability_home_overview_layout
+          - observability_home_overview.panels | map(attribute='id') | list | length == observability_home_overview.panels | map(attribute='id') | list | unique | length
+          - observability_home_overview.links == observability_home_overview_links
+          - observability_home_overview_panels_actual | map(attribute='datasource.uid') | unique | list == ["prometheus"]
+          - observability_home_overview_panels_actual | map(attribute='targets') | flatten | map(attribute='datasource.uid') | unique | list == ["prometheus"]
+          - observability_home_overview_panels_actual | selectattr('title', 'in', observability_home_overview_compact_cards) | map(attribute='gridPos.h') | unique | list == [3]
+          - observability_home_overview_panels_actual | rejectattr('title', 'in', observability_home_overview_compact_cards) | map(attribute='gridPos.h') | unique | difference([5, 6]) | length == 0
+
+    - name: Assert Home Ops overview panels never overlap
+      ansible.builtin.assert:
+        that:
+          - item.0.id == item.1.id or item.0.gridPos.x + item.0.gridPos.w <= item.1.gridPos.x or item.1.gridPos.x + item.1.gridPos.w <= item.0.gridPos.x or item.0.gridPos.y + item.0.gridPos.h <= item.1.gridPos.y or item.1.gridPos.y + item.1.gridPos.h <= item.0.gridPos.y
+      loop: "{{ observability_home_overview.panels | product(observability_home_overview.panels) | list }}"
+      loop_control:
+        label: "{{ item.0.title }} / {{ item.1.title }}"
+      no_log: true
+
+    - name: Select Home Ops overview cards and diagnostic panels
+      ansible.builtin.set_fact:
+        observability_home_overview_cards: "{{ observability_home_overview_panels_actual | selectattr('title', 'in', observability_home_overview_compact_cards) | list }}"
+        observability_core_scrape_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Core scrape services') | first }}"
+        observability_components_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Observability components') | first }}"
+        observability_pvc_health_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'PVC health') | first }}"
+        observability_argocd_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Argo CD applications') | first }}"
+        observability_active_alerts_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Active alerts') | first }}"
+        observability_reachability_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'External reachability') | first }}"
+        observability_node_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Kubernetes node') | first }}"
+        observability_backup_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Backup freshness') | first }}"
+        observability_certificate_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Certificate expiry') | first }}"
+        observability_filesystem_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Node filesystem free') | first }}"
+        observability_restarts_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Pod restarts') | first }}"
+        observability_oom_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'OOM kills') | first }}"
+        observability_trend_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'CPU / memory trend') | first }}"
+        observability_largest_pods_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Largest pods') | first }}"
+        observability_probe_health_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'HTTP / DNS / ICMP health') | first }}"
+        observability_pvc_headroom_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'PVC headroom') | first }}"
+        observability_slowest_http_panel: "{{ observability_home_overview_panels_actual | selectattr('title', 'equalto', 'Slowest HTTP routes') | first }}"
+
+    - name: Assert Home Ops overview card guardrails and health semantics
+      ansible.builtin.assert:
+        that:
+          - observability_home_overview_cards | map(attribute='fieldConfig.defaults.noValue') | unique | list == ["Unavailable"]
+          - observability_home_overview_cards | map(attribute='title') | list == observability_home_overview_compact_cards
+          - observability_home_overview_cards | map(attribute='targets') | map('length') | unique | list == [1]
+          - observability_home_overview_cards | map(attribute='gridPos') | list == observability_home_overview_compact_grid_positions
+          - observability_home_overview_cards | map(attribute='options.colorMode') | unique | list == ["value"]
+          - observability_home_overview_cards | map(attribute='options.graphMode') | unique | list == ["none"]
+          - observability_home_overview_cards | map(attribute='targets') | flatten | map(attribute='expr') | list == observability_home_overview_compact_expressions
+          - observability_backup_panel.targets[0].expr is search('kube_cronjob_status_last_successful_time')
+          - observability_backup_panel.targets[0].expr is search('kube_cronjob_created')
+          - observability_backup_panel.fieldConfig.defaults.thresholds.steps | map(attribute='value') | list == [none, 24, 36]
+          - observability_active_alerts_panel.targets[0].expr is search('grafana_alerting_active_alerts')
+          - observability_active_alerts_panel.targets[0].expr is search('job="victoria-metrics-k8s-stack-grafana"')
+          - observability_reachability_panel.targets[0].expr == '(count(probe_success == 0) or (count(probe_success) * 0)) or vector(-1)'
+          - 'observability_active_alerts_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "No active alerts", "color": "green"}}'
+          - 'observability_reachability_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "All reachable", "color": "green"}}'
+          - 'observability_node_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Not ready", "color": "red"}, "1": {"text": "Ready", "color": "green"}}'
+          - 'observability_argocd_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "All applications healthy", "color": "green"}}'
+          - 'observability_restarts_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "No restarts", "color": "green"}}'
+          - 'observability_oom_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "No OOM kills", "color": "green"}}'
+          - 'observability_pvc_health_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "All PVCs healthy", "color": "green"}}'
+          - 'observability_certificate_panel.fieldConfig.defaults.unit == "suffix: days"'
+          - observability_certificate_panel.fieldConfig.defaults.thresholds.steps | map(attribute='value') | list == [none, 7, 14]
+          - observability_pvc_health_panel.targets[0].expr is search('phase=~"Failed\\|Pending"')
+          - observability_pvc_health_panel.targets[0].expr is search('== 1')
+          - observability_argocd_panel.targets[0].expr is search('health_status')
+          - observability_argocd_panel.targets[0].expr is search('sync_status')
+          - observability_argocd_panel.targets[0].expr is search('count\\(argocd_app_info\\) \\* 0')
+          - observability_filesystem_panel.fieldConfig.defaults.thresholds.steps | map(attribute='value') | list == [none, 10, 20]
+          - observability_restarts_panel.targets[0].expr is search('\\[1h\\]')
+          - observability_oom_panel.targets[0].expr is search('\\[24h\\]')
+          - observability_oom_panel.targets[0].expr == '(sum(increase(container_oom_events_total{job="kubelet",metrics_path="/metrics/cadvisor",container!="",pod!=""}[24h])) or (count(container_oom_events_total{job="kubelet",metrics_path="/metrics/cadvisor",container!="",pod!=""}) * 0)) or vector(-1)'
+          - observability_home_overview_cards | selectattr('title', 'equalto', 'Memory used') | map(attribute='targets') | flatten | map(attribute='expr') | list == ['100 * (1 - avg(node_memory_MemAvailable_bytes{job="node-exporter"} / node_memory_MemTotal_bytes{job="node-exporter"})) or vector(-1)']
+          - observability_largest_pods_panel.type == "bargauge"
+          - observability_largest_pods_panel.targets[0].instant is true
+          - observability_largest_pods_panel.targets[0].expr is search('topk\\(10')
+          - observability_largest_pods_panel.fieldConfig.defaults.thresholds.steps | length == 1
+          - observability_pvc_headroom_panel.targets[0].instant is true
+          - observability_pvc_headroom_panel.targets[0].expr is search('sort\\(bottomk\\(8')
+          - observability_slowest_http_panel.targets[0].instant is true
+          - observability_slowest_http_panel.targets | length == 1
+          - observability_slowest_http_panel.targets[0].expr is search('topk\\(8')
+          - observability_slowest_http_panel.targets[0].legendFormat is search('host')
+          - observability_slowest_http_panel.fieldConfig.defaults.unit == "s"
+          - observability_trend_panel.targets | length == 2
+          - observability_pvc_headroom_panel.targets | length == 1
+          - observability_largest_pods_panel.targets | length == 1
+          - observability_probe_health_panel.targets | length == 3
+          - observability_probe_health_panel.targets | map(attribute='expr') | list == ['min(probe_success{job="prometheus-blackbox-exporter-http"}) or vector(-1)', 'min(probe_success{job="prometheus-blackbox-exporter-dns"}) or vector(-1)', 'min(probe_success{job="prometheus-blackbox-exporter-icmp"}) or vector(-1)']
+          - observability_probe_health_panel.type == "stat"
+          - observability_probe_health_panel.options.colorMode == "value"
+          - observability_probe_health_panel.options.graphMode == "none"
+          - observability_probe_health_panel.options.orientation == "horizontal"
+          - observability_probe_health_panel.options.textMode == "value_and_name"
+          - 'observability_probe_health_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Down", "color": "red"}, "1": {"text": "Healthy", "color": "green"}}'
+          - 'observability_core_scrape_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Down", "color": "red"}, "1": {"text": "Healthy", "color": "green"}}'
+          - 'observability_components_panel.fieldConfig.defaults.mappings[0].options == {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Down", "color": "red"}, "1": {"text": "Healthy", "color": "green"}}'
+          - observability_core_scrape_panel.type == "stat"
+          - observability_core_scrape_panel.options.colorMode == "value"
+          - observability_core_scrape_panel.options.graphMode == "none"
+          - observability_core_scrape_panel.options.orientation == "horizontal"
+          - observability_core_scrape_panel.options.textMode == "value_and_name"
+          - observability_components_panel.type == "stat"
+          - observability_components_panel.options.colorMode == "value"
+          - observability_components_panel.options.graphMode == "none"
+          - observability_components_panel.options.orientation == "horizontal"
+          - observability_components_panel.options.textMode == "value_and_name"
+          - 'observability_home_overview | to_json is search(''"1": {"text": "Ready"'')'
+          - 'observability_home_overview | to_json is search(''"0": {"text": "Not ready"'')'
+          - 'observability_home_overview | to_json is search(''"1": {"text": "Healthy"'')'
+          - 'observability_home_overview | to_json is search(''"0": {"text": "Down"'')'
+          - 'observability_home_overview | to_json is search(''"0": {"text": "No active alerts"'')'
+          - 'observability_home_overview | to_json is search(''"0": {"text": "All PVCs healthy"'')'
+          - observability_home_overview_rows_actual | map(attribute='gridPos.y') | list == [0, 4, 8, 24]
+          - 'observability_trend_panel.gridPos == {"x": 0, "y": 12, "w": 12, "h": 6}'
+          - 'observability_pvc_headroom_panel.gridPos == {"x": 12, "y": 12, "w": 12, "h": 6}'
+          - 'observability_largest_pods_panel.gridPos == {"x": 0, "y": 18, "w": 24, "h": 6}'
+          - 'observability_probe_health_panel.gridPos == {"x": 0, "y": 25, "w": 8, "h": 5}'
+          - 'observability_slowest_http_panel.gridPos == {"x": 8, "y": 25, "w": 16, "h": 5}'
+          - 'observability_core_scrape_panel.gridPos == {"x": 0, "y": 30, "w": 12, "h": 6}'
+          - 'observability_components_panel.gridPos == {"x": 12, "y": 30, "w": 12, "h": 6}'
+
+    - name: Assert Home Ops overview service coverage is exact
+      ansible.builtin.assert:
+        that:
+          - observability_core_scrape_panel.targets | length == 4
+          - observability_core_scrape_panel.targets | map(attribute='expr') | list == ['min(up{job="node-exporter"}) or vector(-1)', 'min(up{job="kubelet"}) or vector(-1)', 'min(up{job="kube-state-metrics"}) or vector(-1)', 'min(up{job="prometheus-blackbox-exporter"}) or vector(-1)']
+          - observability_components_panel.targets | length == 6
+          - observability_components_panel.targets | map(attribute='expr') | list == ['min(up{job="vmsingle-victoria-metrics-k8s-stack"}) or vector(-1)', 'min(up{job="vmagent-victoria-metrics-k8s-stack"}) or vector(-1)', 'min(up{job="victoria-metrics-k8s-stack-victoria-metrics-operator"}) or vector(-1)', 'min(up{job="victoria-logs-single-server"}) or vector(-1)', 'min(up{job="platform-system/victoria-logs-collector"}) or vector(-1)', 'min(up{job="victoria-metrics-k8s-stack-grafana"}) or vector(-1)']
+          - observability_components_panel.targets | map(attribute='expr') | select('search', 'reloader') | list | length == 0
 
     - name: Check forbidden observability app directories
       ansible.builtin.stat:

--- a/apps/platform-system/victoria-metrics-k8s-stack/manifests/victoria-metrics-k8s-stack-home-ops-overview.configmap.yaml
+++ b/apps/platform-system/victoria-metrics-k8s-stack/manifests/victoria-metrics-k8s-stack-home-ops-overview.configmap.yaml
@@ -11,1273 +11,142 @@ metadata:
 data:
   home-ops-overview.json: |-
     {
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": {
-              "type": "grafana",
-              "uid": "-- Grafana --"
-            },
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-          }
-        ]
-      },
+      "annotations": {"list": []},
       "editable": false,
-      "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": null,
-      "links": [],
-      "liveNow": false,
+      "links": [
+        {"title": "Node Exporter Full", "type": "link", "url": "/d/rYdddlPWk/node-exporter-full"},
+        {"title": "VictoriaMetrics Single", "type": "link", "url": "/d/wNf0q_kZk/victoriametrics-single-node"},
+        {"title": "VictoriaLogs Single", "type": "link", "url": "/d/OqPIZTX4z/victorialogs-single-node"},
+        {"title": "Pod Logs Explorer", "type": "link", "url": "/d/home-ops-pod-logs/kubernetes-pod-logs"}
+      ],
       "panels": [
+        {"id": 1, "title": "Current status", "type": "row", "collapsed": false, "gridPos": {"x": 0, "y": 0, "w": 24, "h": 1}, "panels": []},
         {
-          "id": 1,
-          "title": "Routes and platform",
-          "type": "row",
-          "collapsed": false,
-          "gridPos": {
-            "x": 0,
-            "y": 0,
-            "w": 24,
-            "h": 1
-          },
-          "panels": []
+          "id": 2, "title": "Active alerts", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 1, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "short", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "No active alerts", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "sum(grafana_alerting_active_alerts{job=\"victoria-metrics-k8s-stack-grafana\"}) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 2,
-          "title": "Route health",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 1,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "min(probe_success)",
-              "legendFormat": "All probes",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 3, "title": "External reachability", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 6, "y": 1, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "short", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "All reachable", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "(count(probe_success == 0) or (count(probe_success) * 0)) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 3,
-          "title": "Probe latency",
-          "type": "timeseries",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 6,
-            "y": 1,
-            "w": 18,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "s",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "red",
-                    "value": 90
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "probe_duration_seconds",
-              "legendFormat": "{{ instance }} · {{ module }}",
-              "range": true,
-              "instant": false,
-              "refId": "A"
-            }
-          ]
+          "id": 4, "title": "Kubernetes node", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 12, "y": 1, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "none", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Not ready", "color": "red"}, "1": {"text": "Ready", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(kube_node_status_condition{job=\"kube-state-metrics\",condition=\"Ready\",status=\"true\"}) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 4,
-          "title": "Unhealthy Argo CD applications",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 6,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "short",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 3
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "sum(argocd_app_info{health_status!~\"Healthy|Progressing\"})",
-              "legendFormat": "Unhealthy apps",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 5, "title": "Backup freshness", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 18, "y": 1, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "h", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 24}, {"color": "red", "value": 36}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "(((time() - max(kube_cronjob_status_last_successful_time{namespace=\"selfhosted\",cronjob=\"restic-backup\"})) or (time() - max(kube_cronjob_created{namespace=\"selfhosted\",cronjob=\"restic-backup\"}))) / 3600) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
+        },
+        {"id": 6, "title": "Workloads and safety", "type": "row", "collapsed": false, "gridPos": {"x": 0, "y": 4, "w": 24, "h": 1}, "panels": []},
+        {
+          "id": 7, "title": "Argo CD applications", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 5, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "short", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "All applications healthy", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}, {"color": "red", "value": 3}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "(sum((argocd_app_info{health_status!~\"Healthy|Progressing\"} == 1) or (argocd_app_info{sync_status!=\"Synced\"} == 1)) or (count(argocd_app_info) * 0)) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 5,
-          "title": "Certificate days remaining",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 6,
-            "y": 6,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "d",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 7
-                  },
-                  {
-                    "color": "green",
-                    "value": 30
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "(min(certmanager_certificate_expiration_timestamp_seconds) - time()) / 86400",
-              "legendFormat": "Minimum days",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 8, "title": "Certificate expiry", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 6, "y": 5, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "suffix: days", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 7}, {"color": "green", "value": 14}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min((certmanager_certificate_expiration_timestamp_seconds - time()) / 86400) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 6,
-          "title": "Pod restarts (1h)",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 12,
-            "y": 6,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "short",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 5
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(kube_pod_container_status_restarts_total{container!=\"POD\"}[1h]))",
-              "legendFormat": "Restarts",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 9, "title": "Pod restarts", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 12, "y": 5, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "short", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "No restarts", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}, {"color": "red", "value": 5}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "(sum(increase(kube_pod_container_status_restarts_total[1h])) or (count(kube_pod_container_status_restarts_total) * 0)) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 7,
-          "title": "Container OOM events (24h)",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 18,
-            "y": 6,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "short",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 2
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(container_oom_events_total{container!=\"\",pod!=\"\"}[24h]))",
-              "legendFormat": "OOM events",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 10, "title": "OOM kills", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 18, "y": 5, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "short", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "No OOM kills", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}, {"color": "red", "value": 3}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "(sum(increase(container_oom_events_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",container!=\"\",pod!=\"\"}[24h])) or (count(container_oom_events_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",container!=\"\",pod!=\"\"}) * 0)) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
+        },
+        {"id": 11, "title": "Capacity", "type": "row", "collapsed": false, "gridPos": {"x": 0, "y": 8, "w": 24, "h": 1}, "panels": []},
+        {
+          "id": 12, "title": "CPU used", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 9, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "percent", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 80}, {"color": "red", "value": 90}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}[5m]))) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 8,
-          "title": "Node capacity",
-          "type": "row",
-          "collapsed": false,
-          "gridPos": {
-            "x": 0,
-            "y": 11,
-            "w": 24,
-            "h": 1
-          },
-          "panels": []
+          "id": 13, "title": "Memory used", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 6, "y": 9, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "percent", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 80}, {"color": "red", "value": 90}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "100 * (1 - avg(node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 9,
-          "title": "Node readiness",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 12,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "min(kube_node_status_condition{job=\"kube-state-metrics\",condition=\"Ready\",status=\"true\"})",
-              "legendFormat": "Ready",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 14, "title": "Node filesystem free", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 12, "y": 9, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "percent", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 10}, {"color": "green", "value": 20}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(100 * node_filesystem_avail_bytes{job=\"node-exporter\",fstype!~\"tmpfs|fuse.*|overlay|squashfs\"} / node_filesystem_size_bytes{job=\"node-exporter\",fstype!~\"tmpfs|fuse.*|overlay|squashfs\"}) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 10,
-          "title": "CPU usage",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 6,
-            "y": 12,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "percent",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "red",
-                    "value": 95
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}[5m])))",
-              "legendFormat": "CPU",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 15, "title": "PVC health", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 18, "y": 9, "w": 6, "h": 3},
+          "fieldConfig": {"defaults": {"unit": "short", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "All PVCs healthy", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "(sum(kube_persistentvolume_status_phase{phase=~\"Failed|Pending\",job=\"kube-state-metrics\"} == 1) or (count(kube_persistentvolume_status_phase{phase=~\"Failed|Pending\",job=\"kube-state-metrics\"}) * 0)) or vector(-1)", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 11,
-          "title": "Memory usage",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 12,
-            "y": 12,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "percent",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 90
-                  },
-                  {
-                    "color": "red",
-                    "value": 95
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})",
-              "legendFormat": "Memory",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 17, "title": "CPU / memory trend", "type": "timeseries", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 12, "w": 12, "h": 6},
+          "fieldConfig": {"defaults": {"unit": "percent", "color": {"mode": "palette-classic"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}[5m])))", "legendFormat": "CPU", "instant": false, "range": true, "refId": "A"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "100 * (1 - node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})", "legendFormat": "Memory", "instant": false, "range": true, "refId": "B"}]
         },
         {
-          "id": 12,
-          "title": "Lowest filesystem free",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 18,
-            "y": 12,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "percent",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 10
-                  },
-                  {
-                    "color": "green",
-                    "value": 20
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "min(100 * node_filesystem_avail_bytes{job=\"node-exporter\",fstype!~\"tmpfs|fuse.*|overlay|squashfs\"} / node_filesystem_size_bytes{job=\"node-exporter\",fstype!~\"tmpfs|fuse.*|overlay|squashfs\"})",
-              "legendFormat": "Free",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 18, "title": "PVC headroom", "type": "bargauge", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 12, "y": 12, "w": 12, "h": 6},
+          "fieldConfig": {"defaults": {"unit": "percent", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 10}, {"color": "green", "value": 20}]}}, "overrides": []},
+          "options": {"displayMode": "gradient", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": false},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "sort(bottomk(8, 100 * kubelet_volume_stats_available_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}))", "legendFormat": "{{ namespace }}/{{ persistentvolumeclaim }}", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 13,
-          "title": "Top pods by working-set memory",
-          "type": "bargauge",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 17,
-            "w": 12,
-            "h": 8
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "bytes",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "red",
-                    "value": 90
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "displayMode": "gradient",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilledArea": true
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "topk(10, sum by (namespace, pod) (container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",container!=\"\",image!=\"\"}))",
-              "legendFormat": "{{ namespace }}/{{ pod }}",
-              "range": true,
-              "instant": false,
-              "refId": "A"
-            }
-          ]
+          "id": 19, "title": "Largest pods", "type": "bargauge", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 18, "w": 24, "h": 6},
+          "fieldConfig": {"defaults": {"unit": "bytes", "noValue": "Unavailable", "color": {"mode": "fixed", "fixedColor": "blue"}, "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]}}, "overrides": []},
+          "options": {"displayMode": "basic", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": false},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "topk(10, sum by (namespace, pod) (container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",container!=\"\",image!=\"\"}))", "legendFormat": "{{ namespace }}/{{ pod }}", "instant": true, "range": false, "refId": "A"}]
+        },
+        {"id": 16, "title": "Service health", "type": "row", "collapsed": false, "gridPos": {"x": 0, "y": 24, "w": 24, "h": 1}, "panels": []},
+        {
+          "id": 20, "title": "HTTP / DNS / ICMP health", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 25, "w": 8, "h": 5},
+          "fieldConfig": {"defaults": {"unit": "none", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Down", "color": "red"}, "1": {"text": "Healthy", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(probe_success{job=\"prometheus-blackbox-exporter-http\"}) or vector(-1)", "legendFormat": "HTTP", "instant": true, "range": false, "refId": "A"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(probe_success{job=\"prometheus-blackbox-exporter-dns\"}) or vector(-1)", "legendFormat": "DNS", "instant": true, "range": false, "refId": "B"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(probe_success{job=\"prometheus-blackbox-exporter-icmp\"}) or vector(-1)", "legendFormat": "ICMP", "instant": true, "range": false, "refId": "C"}]
         },
         {
-          "id": 14,
-          "title": "PVC free space",
-          "type": "timeseries",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 12,
-            "y": 17,
-            "w": 12,
-            "h": 8
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "percent",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "red",
-                    "value": 90
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "100 * kubelet_volume_stats_available_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}",
-              "legendFormat": "{{ namespace }}/{{ persistentvolumeclaim }}",
-              "range": true,
-              "instant": false,
-              "refId": "A"
-            }
-          ]
+          "id": 21, "title": "Slowest HTTP routes", "type": "bargauge", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 8, "y": 25, "w": 16, "h": 5},
+          "fieldConfig": {"defaults": {"unit": "s", "noValue": "Unavailable", "color": {"mode": "continuous-GrYlRd"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}}, "overrides": []},
+          "options": {"displayMode": "gradient", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": false},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "topk(8, label_replace(probe_duration_seconds{job=\"prometheus-blackbox-exporter-http\"}, \"host\", \"$1\", \"instance\", \"https?://([^/]+).*\"))", "legendFormat": "{{ host }}", "instant": true, "range": false, "refId": "A"}]
         },
         {
-          "id": 15,
-          "title": "Backups and monitoring coverage",
-          "type": "row",
-          "collapsed": false,
-          "gridPos": {
-            "x": 0,
-            "y": 25,
-            "w": 24,
-            "h": 1
-          },
-          "panels": []
+          "id": 22, "title": "Core scrape services", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 0, "y": 30, "w": 12, "h": 6},
+          "fieldConfig": {"defaults": {"unit": "none", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Down", "color": "red"}, "1": {"text": "Healthy", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"node-exporter\"}) or vector(-1)", "legendFormat": "Node Exporter", "instant": true, "range": false, "refId": "A"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"kubelet\"}) or vector(-1)", "legendFormat": "Kubelet", "instant": true, "range": false, "refId": "B"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"kube-state-metrics\"}) or vector(-1)", "legendFormat": "kube-state-metrics", "instant": true, "range": false, "refId": "C"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"prometheus-blackbox-exporter\"}) or vector(-1)", "legendFormat": "Blackbox Exporter", "instant": true, "range": false, "refId": "D"}]
         },
         {
-          "id": 16,
-          "title": "Restic backup age",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 26,
-            "w": 6,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "h",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 24
-                  },
-                  {
-                    "color": "red",
-                    "value": 36
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "(time() - kube_cronjob_status_last_successful_time{namespace=\"selfhosted\",cronjob=\"restic-backup\"}) / 3600",
-              "legendFormat": "Hours",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 17,
-          "title": "Core scrape targets",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 6,
-            "y": 26,
-            "w": 18,
-            "h": 5
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "up{job=~\"node-exporter|kube-state-metrics|kubelet|prometheus-blackbox-exporter\"}",
-              "legendFormat": "{{ job }} · {{ instance }}",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 18,
-          "title": "PVC errors",
-          "type": "timeseries",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 31,
-            "w": 8,
-            "h": 6
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "short",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "red",
-                    "value": 90
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "kube_persistentvolume_status_phase{phase=~\"Failed|Pending\",job=\"kube-state-metrics\"}",
-              "legendFormat": "{{ persistentvolume }} · {{ phase }}",
-              "range": true,
-              "instant": false,
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 19,
-          "title": "Node CPU and memory",
-          "type": "timeseries",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 8,
-            "y": 31,
-            "w": 16,
-            "h": 6
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "percent",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "red",
-                    "value": 90
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}[5m])))",
-              "legendFormat": "CPU %",
-              "range": true,
-              "instant": false,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})",
-              "legendFormat": "Memory %",
-              "range": true,
-              "instant": false,
-              "refId": "B"
-            }
-          ]
-        },
-        {
-          "id": 20,
-          "title": "Victoria observability",
-          "type": "row",
-          "collapsed": false,
-          "gridPos": {
-            "x": 0,
-            "y": 37,
-            "w": 24,
-            "h": 1
-          },
-          "panels": []
-        },
-        {
-          "id": 21,
-          "title": "Component scrape health",
-          "type": "stat",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "gridPos": {
-            "x": 0,
-            "y": 38,
-            "w": 24,
-            "h": 6
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "color": {
-                "mode": "thresholds"
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "up{job=~\".*(vmsingle|vmagent|victoria-metrics-operator|victoria-logs-single|victoria-logs-collector|grafana).*\"}",
-              "legendFormat": "{{ job }} · {{ instance }}",
-              "range": false,
-              "instant": true,
-              "refId": "A"
-            }
-          ]
+          "id": 23, "title": "Observability components", "type": "stat", "datasource": {"type": "prometheus", "uid": "prometheus"}, "gridPos": {"x": 12, "y": 30, "w": 12, "h": 6},
+          "fieldConfig": {"defaults": {"unit": "none", "noValue": "Unavailable", "color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"-1": {"text": "Metrics unavailable", "color": "red"}, "0": {"text": "Down", "color": "red"}, "1": {"text": "Healthy", "color": "green"}}}], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}}, "overrides": []},
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"vmsingle-victoria-metrics-k8s-stack\"}) or vector(-1)", "legendFormat": "VMSingle", "instant": true, "range": false, "refId": "A"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"vmagent-victoria-metrics-k8s-stack\"}) or vector(-1)", "legendFormat": "VMAgent", "instant": true, "range": false, "refId": "B"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"victoria-metrics-k8s-stack-victoria-metrics-operator\"}) or vector(-1)", "legendFormat": "VictoriaMetrics Operator", "instant": true, "range": false, "refId": "C"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"victoria-logs-single-server\"}) or vector(-1)", "legendFormat": "VictoriaLogs", "instant": true, "range": false, "refId": "D"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"platform-system/victoria-logs-collector\"}) or vector(-1)", "legendFormat": "VLAgent", "instant": true, "range": false, "refId": "E"}, {"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "min(up{job=\"victoria-metrics-k8s-stack-grafana\"}) or vector(-1)", "legendFormat": "Grafana", "instant": true, "range": false, "refId": "F"}]
         }
       ],
       "refresh": "30s",
       "schemaVersion": 41,
-      "tags": [
-        "home-ops",
-        "operations"
-      ],
-      "templating": {
-        "list": []
-      },
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      },
-      "timepicker": {
-        "refresh_intervals": [
-          "30s",
-          "1m",
-          "5m",
-          "15m"
-        ]
-      },
+      "tags": ["home-ops", "operations"],
+      "templating": {"list": []},
+      "time": {"from": "now-6h", "to": "now"},
       "timezone": "browser",
       "title": "Home Ops Overview",
       "uid": "home-ops-overview",
-      "version": 1,
-      "weekStart": "monday"
+      "version": 1
     }


### PR DESCRIPTION
## Summary

- redesign Home Ops Overview around four action-first sections and responsive card ordering
- replace raw binary states and empty healthy panels with semantic mappings and missing-metric sentinels
- bound noisy route, PVC, and pod diagnostics while preserving five dashboards, 20 alerts, raw metrics, and existing datasources
- strengthen the observability contract for exact inventory, layout, mappings, expressions, dashboard links, and service coverage

## Validation

- task fmt:check
- task lint:ansible
- task lint:kubernetes
- task fmt
- task lint
- all dashboard PromQL expressions against the live Grafana datasource
- synthetic failure/success/absent sentinel scenarios
- independent task and whole-branch reviews