### PR TITLE
fix(renovate): filter legacy qBittorrent image tags

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -136,6 +136,14 @@
       overridePackageName: "ghcr.io/siderolabs/installer",
     },
 
+    // LinuxServer retains historic base-image tags such as 20.04.1 alongside qBittorrent releases.
+    {
+      description: "Ignore legacy LinuxServer qBittorrent base-image tags",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["lscr.io/linuxserver/qbittorrent"],
+      allowedVersions: "/^[1-9]\\.[0-9]+\\.[0-9]+$/",
+    },
+
     // Manual review: Gateway API updates (CRD changes are risky)
     {
       description: "Require manual review for Gateway API updates",

--- a/apps/media/qbittorrent/values.yaml
+++ b/apps/media/qbittorrent/values.yaml
@@ -18,7 +18,7 @@ controllers:
       app:
         image:
           repository: lscr.io/linuxserver/qbittorrent
-          tag: 5.2.3
+          tag: 20.04.1
         env:
           PUID: "1000"
           PGID: "1000"

--- a/apps/media/qbittorrent/values.yaml
+++ b/apps/media/qbittorrent/values.yaml
@@ -18,7 +18,7 @@ controllers:
       app:
         image:
           repository: lscr.io/linuxserver/qbittorrent
-          tag: 20.04.1
+          tag: 5.2.3
         env:
           PUID: "1000"
           PGID: "1000"


### PR DESCRIPTION
Renovate interpreted the historical LinuxServer 20.04.1 base/package tag as a qBittorrent major release. Registry metadata shows that tag is a 2021 image containing qBittorrent 4.3.9, so the original change would downgrade the current 5.2.3 deployment.

This repair:
- keeps the qBittorrent image at 5.2.3
- restricts this package to current single-digit semantic release tags
- filters historical 14.3.9 and 20.04.1 tags

Validation:
- strict Renovate configuration validation
- regression probe allowing 5.2.3 and rejecting 14.3.9 / 20.04.1
- full task lint