### PR TITLE
fix(karakeep): migrate to maintained browser image

### DIFF
--- a/ansible/tests/karakeep-browser.yml
+++ b/ansible/tests/karakeep-browser.yml
@@ -1,0 +1,28 @@
+---
+- name: Validate Karakeep browser integration
+  hosts: localhost
+  gather_facts: false
+  vars:
+    karakeep_browser_repo_root: "{{ playbook_dir }}/../.."
+
+  tasks:
+    - name: Load Karakeep values
+      ansible.builtin.include_vars:
+        file: "{{ karakeep_browser_repo_root }}/apps/selfhosted/karakeep/values.yaml"
+        name: karakeep_browser_values
+
+    - name: Require the maintained Karakeep browser image
+      ansible.builtin.assert:
+        that:
+          - karakeep_browser_values.controllers.chrome.containers.app.image.repository == 'ghcr.io/karakeep-app/karakeep-chrome'
+          - karakeep_browser_values.controllers.chrome.containers.app.image.tag is match('^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+-r[0-9]+$')
+        fail_msg: "Karakeep must use a versioned release of its maintained browser image."
+
+    - name: Preserve the browser image port-forwarding entrypoint
+      ansible.builtin.assert:
+        that:
+          - karakeep_browser_values.controllers.chrome.containers.app.command is not defined
+          - "'--no-sandbox' not in karakeep_browser_values.controllers.chrome.containers.app.args"
+          - "'--disable-software-rasterizer' not in karakeep_browser_values.controllers.chrome.containers.app.args"
+          - karakeep_browser_values.controllers.chrome.containers.app.args | select('match', '^--remote-debugging-(address|port)(=|$)') | list | length == 0
+        fail_msg: "Karakeep browser arguments must not override the image entrypoint's internal port forwarding."

--- a/apps/selfhosted/karakeep/values.yaml
+++ b/apps/selfhosted/karakeep/values.yaml
@@ -88,19 +88,14 @@ controllers:
     containers:
       app:
         image:
-          repository: gcr.io/zenika-hub/alpine-chrome
-          tag: "124"
-        command:
-          - chromium-browser
+          repository: ghcr.io/karakeep-app/karakeep-chrome
+          tag: 151.0.7922.47-r1
         args:
-          - --headless
-          - --no-sandbox
           - --disable-gpu
-          - --disable-software-rasterizer
           - --disable-dev-shm-usage
-          - --remote-debugging-address=0.0.0.0
-          - --remote-debugging-port=9222
           - --hide-scrollbars
+          - --disable-blink-features=AutomationControlled
+          - --window-size=1440,900
         probes:
           startup:
             enabled: true


### PR DESCRIPTION
Karakeep 0.33.2 recommends replacing the abandoned Alpine Chrome image, whose GCR registry now rejects fresh pulls. This migrates the Chrome controller to the official multi-architecture Karakeep image, removes arguments that conflict with its internal port-forwarding entrypoint, and adds a contract covering the integration.

Addresses the package lookup warning in #31 without closing the persistent Dependency Dashboard.

Validation: full task lint; regression contract observed failing before the migration and passing afterward; image smoke test as UID/GID 1000 with no added capabilities; local Renovate extraction and lookup returned the package with no warnings.