### PR TITLE
chore(apps): update OpenAI models

### DIFF
--- a/apps/selfhosted/changedetection/values.yaml
+++ b/apps/selfhosted/changedetection/values.yaml
@@ -26,7 +26,7 @@ controllers:
           FETCH_WORKERS: "10"
           PLAYWRIGHT_DRIVER_URL: ws://127.0.0.1:3000
           DISABLE_VERSION_CHECK: "true"
-          LLM_MODEL: gpt-5-mini
+          LLM_MODEL: gpt-5.6-luna
           LLM_MAX_INPUT_CHARS: "20000"
         envFrom:
           - secretRef:

--- a/apps/selfhosted/karakeep/values.yaml
+++ b/apps/selfhosted/karakeep/values.yaml
@@ -34,8 +34,8 @@ controllers:
               secretKeyRef:
                 name: karakeep-credentials
                 key: OPENAI_API_KEY
-          INFERENCE_TEXT_MODEL: gpt-5-mini
-          INFERENCE_IMAGE_MODEL: gpt-5-mini
+          INFERENCE_TEXT_MODEL: gpt-5.6-luna
+          INFERENCE_IMAGE_MODEL: gpt-4o-mini
           INFERENCE_CONTEXT_LENGTH: "4096"
           INFERENCE_ENABLE_AUTO_SUMMARIZATION: "true"
           INFERENCE_ENABLE_AUTO_TAGGING: "true"

--- a/apps/selfhosted/paperless/values.yaml
+++ b/apps/selfhosted/paperless/values.yaml
@@ -141,9 +141,9 @@ controllers:
           PAPERLESS_BASE_URL: http://paperless-main.selfhosted.svc.cluster.local:8000
           PAPERLESS_PUBLIC_URL: https://paperless.edgard.org
           LLM_PROVIDER: openai
-          LLM_MODEL: gpt-5-mini
+          LLM_MODEL: gpt-5.6-luna
           VISION_LLM_PROVIDER: openai
-          VISION_LLM_MODEL: gpt-5-mini
+          VISION_LLM_MODEL: gpt-5.6-terra
           OCR_PROVIDER: "llm"
           PDF_SKIP_EXISTING_OCR: "false"
           PDF_OCR_TAGGING: "false"


### PR DESCRIPTION
## Summary

- move Changedetection and Paperless text generation to `gpt-5.6-luna`
- move Paperless vision/OCR to `gpt-5.6-terra`
- align Karakeep with its current upstream defaults: `gpt-5.6-luna` for text and `gpt-4o-mini` for images
- leave embeddings and OpenAI integration settings unchanged

## Validation

- `task fmt`
- `task lint:ansible`
- `task lint:kubernetes`
- rendered manifest inspection for all five model environment variables
- `task lint`

## References

- https://developers.openai.com/api/docs/models/gpt-5.6-luna
- https://developers.openai.com/api/docs/models/gpt-5.6-terra
- https://github.com/karakeep-app/karakeep/blob/v0.33.2/packages/shared/config.ts#L91-L92